### PR TITLE
Fix for TCAP-214

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/MavenBuildInfoExtractor.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/MavenBuildInfoExtractor.java
@@ -206,7 +206,7 @@ public class MavenBuildInfoExtractor extends BaseBuildInfoExtractor<File> {
             ArtifactBuilder artifactBuilder = new ArtifactBuilder(artifactName);
             artifactBuilder.type(gavc.type);
 
-            if (artifactFile.exists()) {
+            if (artifactFile.isFile()) {
 
                 String deploymentRepo = getDeploymentRepo(gavc);
                 addChecksumInfo(artifactFile, deploymentRepo, deploymentPath, artifactBuilder);


### PR DESCRIPTION
Proposed fix for https://www.jfrog.com/jira/browse/TCAP-214
"ArtifactFile" returned by Maven API may point to a directory. E.g., when for "test" lifecycle phase.
