### PR TITLE
Adding support for merging release into master

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/release/ReleaseParameters.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/release/ReleaseParameters.java
@@ -96,6 +96,10 @@ public class ReleaseParameters {
         return buildParams.get(ReleaseManagementParameterKeys.NEXT_DEVELOPMENT_VERSION_COMMENT);
     }
 
+    public String getMergeReleaseIntoMasterComment() {
+        return buildParams.get(ReleaseManagementParameterKeys.MERGE_MASTER_COMMENT);
+    }
+
     public boolean isCreateReleaseBranch() {
         return getBoolean(ReleaseManagementParameterKeys.CREATE_RELEASE_BRANCH);
     }
@@ -122,6 +126,10 @@ public class ReleaseParameters {
 
     public boolean isGit() {
         return getBoolean(ReleaseManagementParameterKeys.GIT_VCS);
+    }
+
+    public boolean isUseGitflow() {
+        return getBoolean(ReleaseManagementParameterKeys.USE_GITFLOW);
     }
 
     public boolean isPerforce() {

--- a/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCoordinator.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCoordinator.java
@@ -127,7 +127,11 @@ public class GitCoordinator extends AbstractVcsCoordinator {
         if (releaseParameters.isUseGitflow()) {
             git.checkoutBranch("master", false);
 
-            git.mergeNoFF(releaseBranch, releaseParameters.getMergeReleaseIntoMasterComment());
+            if (releaseParameters.isCreateReleaseBranch()) {
+                git.mergeNoFF(releaseBranch, releaseParameters.getMergeReleaseIntoMasterComment());
+            } else {
+                git.mergeNoFF(checkoutBranch, releaseParameters.getMergeReleaseIntoMasterComment());
+            }
 
             git.push(getPushUrl(), "master");
         }

--- a/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCoordinator.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCoordinator.java
@@ -123,6 +123,14 @@ public class GitCoordinator extends AbstractVcsCoordinator {
             git.pushTag(getPushUrl(), releaseParameters.getTagUrl());
             state.tagPushed = true;
         }
+
+        if (releaseParameters.isUseGitflow()) {
+            git.checkoutBranch("master", false);
+
+            git.mergeNoFF(releaseBranch, releaseParameters.getMergeReleaseIntoMasterComment());
+
+            git.push(getPushUrl(), "master");
+        }
     }
 
     public void beforeDevelopmentVersionChange() throws IOException {

--- a/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitManager.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitManager.java
@@ -77,6 +77,19 @@ public class GitManager extends AbstractScmManager {
         return baseCommit;
     }
 
+    public String mergeNoFF(String mergeWith, String message) throws IOException {
+        List<String> command = new ArrayList<String>();
+        command.add("merge");
+        command.add("--no-ff");
+        command.add("-m");
+        command.add(message);
+        command.add("--log");
+        command.add(expandNoHeadsRef(mergeWith));
+        String mergeResult = git.launchCommand(command.toArray(new String[command.size()]));
+        debuggingLogger.fine(String.format("Merge result: %s", mergeResult));
+        return mergeResult;
+    }
+
     public String checkoutBranch(String branch, boolean create) throws IOException {
         // commit all the modified files
         List<String> command = new ArrayList<String>();

--- a/common/src/main/java/org/jfrog/teamcity/common/ReleaseManagementParameterKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/ReleaseManagementParameterKeys.java
@@ -7,6 +7,8 @@ public class ReleaseManagementParameterKeys {
 
     private final static String PREFIX = ConstantValues.PLUGIN_PREFIX + "releaseManagement.";
 
+    public final static String USE_GITFLOW = PREFIX + "useGitflow";
+    public final static String MERGE_MASTER_COMMENT = PREFIX + "mergeReleaseIntoMasterComment";
     public final static String MANAGEMENT_ACTIVATED = PREFIX + "activated";
     public final static String USE_GLOBAL_VERSION = PREFIX + "useGlobalVersion";
     public final static String GLOBAL_RELEASE_VERSION = PREFIX + "globalReleaseVersion";

--- a/server/src/main/java/org/jfrog/teamcity/server/project/ReleaseManagementConfigModel.java
+++ b/server/src/main/java/org/jfrog/teamcity/server/project/ReleaseManagementConfigModel.java
@@ -38,6 +38,7 @@ public abstract class ReleaseManagementConfigModel {
     private String defaultStagingRepository;
     private String defaultModuleVersionConfiguration;
 
+    private boolean useGitflow = true;
     private boolean gitVcs = false;
     protected boolean svnVcs = false;
     private boolean selectedArtifactoryServerHasAddons = false;
@@ -125,6 +126,18 @@ public abstract class ReleaseManagementConfigModel {
 
     public String getDefaultNextDevelopmentVersionComment() {
         return COMMIT_COMMENT_PREFIX + "Next development version";
+    }
+
+    public String getDefaultMergeReleaseIntoMasterComment() {
+        return COMMIT_COMMENT_PREFIX + "Merging release into master";
+    }
+
+    public boolean isUseGitflow() {
+        return useGitflow;
+    }
+
+    public void setUseGitflow(boolean useGitflow) {
+        this.useGitflow = useGitflow;
     }
 
     public boolean isGitVcs() {

--- a/server/src/main/resources/buildServerResources/mavenReleaseManagementTab.jsp
+++ b/server/src/main/resources/buildServerResources/mavenReleaseManagementTab.jsp
@@ -410,6 +410,28 @@ The next development version (i.e., SNAPSHOT) to use in Maven poms after a succe
             <span class="smallNote">The comment to use when committing changes for the next development version.</span>
         </td>
     </tr>
+    <tr>
+        <th>
+            <forms:checkbox name="org.jfrog.artifactory.releaseManagement.useGitflow" checked="${managementConfig.useGitflow}"/>
+            <label style="float:none; padding-left: 5px; font-weight: bold"
+                   for="org.jfrog.artifactory.releaseManagement.useGitflow">Use Gitflow workflow</label>
+        </th>
+        <td>
+
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <label style="font-weight: normal"
+                   for="org.jfrog.artifactory.releaseManagement.mergeReleaseIntoMasterComment">Merge release into master comment: </label>
+        </th>
+        <td>
+            <forms:textField name="org.jfrog.artifactory.releaseManagement.mergeReleaseIntoMasterComment"
+                             value="${managementConfig.defaultMergeReleaseIntoMasterComment}"
+                             className="longField"/>
+            <span class="smallNote">The comment to use when merging the release into master.</span>
+        </td>
+    </tr>
 </table>
 
 <h2 class="noBorder" style="padding-top: 5px; padding-bottom: 15px">


### PR DESCRIPTION
In order for the plugin to support a version of the gitflow plugin we need to merge the release branch back into master. My changes add this functionality. It is enabled by default because I am using these changes in our TeamCity instance.

The changes add two new fields to the release dialog. A checkbox to define whether you want the merge or not and the merge message. Merges are always done as commits, no fast forward.

I hope this might help you in adding the functionality to the official plugin.
