### PR TITLE
Upgrade build-info to 2.13.0

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/BaseBuildInfoExtractor.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/BaseBuildInfoExtractor.java
@@ -54,7 +54,7 @@ import static org.jfrog.teamcity.common.ConstantValues.*;
 /**
  * @author Noam Y. Tenne
  */
-public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P, ExtractedBuildInfo> {
+public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P> {
 
     protected BuildRunnerContext runnerContext;
     protected Map<String, String> runnerParams;
@@ -62,6 +62,7 @@ public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P,
     protected BuildProgressLogger logger;
     private Multimap<File, String> artifactsToPublish;
     private List<Dependency> publishedDependencies;
+    private List<DeployDetailsArtifact> deployableArtifacts;
     private Map<String, Map<String, String>> calculatedChecksumCache;
 
     public BaseBuildInfoExtractor(BuildRunnerContext runnerContext, Multimap<File, String> artifactsToPublish,
@@ -76,7 +77,7 @@ public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P,
         calculatedChecksumCache = Maps.newHashMap();
     }
 
-    public ExtractedBuildInfo extract(P context) {
+    public Build extract(P context) {
         BuildInfoBuilder builder = getBuildInfoBuilder();
         if (builder == null) {
             return null;
@@ -89,7 +90,7 @@ public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P,
             return null;
         }
 
-        List<DeployDetailsArtifact> deployableArtifacts = Lists.newArrayList();
+        deployableArtifacts = Lists.newArrayList();
         List<DeployDetailsArtifact> runnerSpecificDeployableArtifacts = getDeployableArtifacts();
         if (runnerSpecificDeployableArtifacts != null) {
             deployableArtifacts.addAll(runnerSpecificDeployableArtifacts);
@@ -125,7 +126,11 @@ public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P,
                     runnerParams.get(PROP_PARENT_NUMBER));
         }
 
-        return new ExtractedBuildInfo(buildInfo, deployableArtifacts);
+        return buildInfo;
+    }
+
+    public List<DeployDetailsArtifact> getDeployableArtifact() {
+        return this.deployableArtifacts;
     }
 
     protected abstract void appendRunnerSpecificDetails(BuildInfoBuilder builder, P context)

--- a/agent/src/main/java/org/jfrog/teamcity/agent/GenericBuildInfoExtractor.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/GenericBuildInfoExtractor.java
@@ -27,7 +27,7 @@ import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.builder.BuildInfoBuilder;
 import org.jfrog.build.api.builder.ModuleBuilder;
 import org.jfrog.build.client.DeployDetailsArtifact;
-import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryBuildInfoClientBuilder;
 import org.jfrog.build.extractor.clientConfiguration.util.spec.SpecsHelper;
 import org.jfrog.teamcity.agent.util.SpecHelper;
 import org.jfrog.teamcity.agent.util.TeamcityAgenBuildInfoLog;
@@ -45,12 +45,12 @@ import java.util.List;
 public class GenericBuildInfoExtractor extends BaseBuildInfoExtractor<Object> {
 
     List<Artifact> deployedArtifacts = new ArrayList<Artifact>();
-    ArtifactoryBuildInfoClient infoClient = null;
+    ArtifactoryBuildInfoClientBuilder buildInfoClientBuilder;
 
     public GenericBuildInfoExtractor(BuildRunnerContext runnerContext, Multimap<File, String> artifactsToPublish,
-                                     List<Dependency> publishedDependencies, ArtifactoryBuildInfoClient infoClient) {
+                                     List<Dependency> publishedDependencies, ArtifactoryBuildInfoClientBuilder infoClient) {
         super(runnerContext, artifactsToPublish, publishedDependencies);
-        this.infoClient = infoClient;
+        this.buildInfoClientBuilder = infoClient;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class GenericBuildInfoExtractor extends BaseBuildInfoExtractor<Object> {
         }
 
         try {
-            deployedArtifacts = specsHelper.uploadArtifactsBySpec(uploadSpec, runnerContext.getWorkingDirectory(), matrixParams, infoClient);
+            deployedArtifacts = specsHelper.uploadArtifactsBySpec(uploadSpec, runnerContext.getWorkingDirectory(), matrixParams, buildInfoClientBuilder);
         } catch (IOException e) {
             throw new Exception(
                     String.format("Could not collect artifacts details from the spec: %s", e.getMessage()), e);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
@@ -157,6 +157,7 @@ public class AgentListenerBuildInfoHelper {
             String m = "Could not generate build-info.";
             Loggers.AGENT.warn(m);
             build.getBuildLogger().warning(m);
+            infoClient.close();
             return;
         }
 

--- a/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
@@ -234,10 +234,11 @@ public class AgentListenerBuildInfoHelper {
 
         if (runnerParams.containsKey(PROXY_HOST)) {
             ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
-            proxyConfiguration.host = runnerParams.get(PROXY_USERNAME);
+            proxyConfiguration.host = runnerParams.get(PROXY_HOST);
             proxyConfiguration.port = Integer.parseInt(runnerParams.get(PROXY_PORT));
-            if (StringUtils.isNotBlank(runnerParams.get(PROXY_USERNAME))) {
-                proxyConfiguration.username = runnerParams.get(PROXY_USERNAME);
+            String proxyUsername = runnerParams.get(PROXY_USERNAME);
+            if (StringUtils.isNotBlank(proxyUsername)) {
+                proxyConfiguration.username = proxyUsername;
                 proxyConfiguration.password = runnerParams.get(PROXY_PASSWORD);
             }
             builder.setProxyConfiguration(proxyConfiguration);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/listener/AgentListenerBuildInfoHelper.java
@@ -32,15 +32,13 @@ import org.jfrog.build.api.BuildRetention;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.dependency.BuildDependency;
 import org.jfrog.build.client.DeployDetailsArtifact;
-import org.jfrog.build.extractor.BuildInfoExtractor;
+import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryBuildInfoClientBuilder;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
-import org.jfrog.teamcity.agent.DependenciesResolver;
-import org.jfrog.teamcity.agent.GenericBuildInfoExtractor;
-import org.jfrog.teamcity.agent.LoggingArtifactsBuilderAdapter;
-import org.jfrog.teamcity.agent.MavenBuildInfoExtractor;
+import org.jfrog.teamcity.agent.*;
 import org.jfrog.teamcity.agent.api.ExtractedBuildInfo;
 import org.jfrog.teamcity.agent.util.BuildRetentionFactory;
 import org.jfrog.teamcity.agent.util.TeamcityAgenBuildInfoLog;
@@ -152,7 +150,7 @@ public class AgentListenerBuildInfoHelper {
         BuildProgressLogger logger = build.getBuildLogger();
 
         String selectedServerUrl = runnerParams.get(RunnerParameterKeys.URL);
-        ArtifactoryBuildInfoClient infoClient = getBuildInfoClient(selectedServerUrl, runnerParams, logger);
+        ArtifactoryBuildInfoClient infoClient = getBuildInfoClient(selectedServerUrl, runnerParams, logger).build();
         ExtractedBuildInfo extractedBuildInfo = extractBuildInfo(runner, dependencies, selectedServerUrl, runnerParams, logger);
 
         if (extractedBuildInfo == null) {
@@ -203,7 +201,7 @@ public class AgentListenerBuildInfoHelper {
         }
     }
 
-    private ExtractedBuildInfo extractBuildInfo(BuildRunnerContext runnerContext, List<Dependency> dependencies, String selectedServerUrl, Map<String, String> runnerParams, BuildProgressLogger logger) {
+    private ExtractedBuildInfo extractBuildInfo(BuildRunnerContext runnerContext, List<Dependency> dependencies, String selectedServerUrl, Map<String, String> runnerParams, BuildProgressLogger logger) throws Exception {
         AgentRunningBuild build = runnerContext.getBuild();
         Multimap<File, String> publishableArtifacts = getPublishableArtifacts(runnerContext);
         if (RunTypeUtils.isMavenRunType(runnerContext.getRunType())) {
@@ -216,39 +214,34 @@ public class AgentListenerBuildInfoHelper {
                 throw new RuntimeException("Error occurred during build info collection. Skipping deployment.");
             }
 
-            BuildInfoExtractor<File, ExtractedBuildInfo> buildInfoExtractor = new MavenBuildInfoExtractor(
-                    runnerContext, publishableArtifacts, dependencies);
-            return buildInfoExtractor.extract(mavenBuildInfoFile);
+            BaseBuildInfoExtractor<File> buildInfoExtractor = new MavenBuildInfoExtractor(runnerContext, publishableArtifacts, dependencies);
+            return new ExtractedBuildInfo(buildInfoExtractor.extract(mavenBuildInfoFile), buildInfoExtractor.getDeployableArtifact());
         }
-        ArtifactoryBuildInfoClient infoClient = getBuildInfoClient(selectedServerUrl, runnerParams, logger);
-        BuildInfoExtractor<Object, ExtractedBuildInfo> buildInfoExtractor = new GenericBuildInfoExtractor(runnerContext, publishableArtifacts, dependencies, infoClient);
-        try {
-            return buildInfoExtractor.extract(null);
-        } finally {
-            infoClient.close();
-        }
+        ArtifactoryBuildInfoClientBuilder buildInfoClientBuilder = getBuildInfoClient(selectedServerUrl, runnerParams, logger);
+        GenericBuildInfoExtractor buildInfoExtractor = new GenericBuildInfoExtractor(runnerContext, publishableArtifacts, dependencies, buildInfoClientBuilder);
+
+        return new ExtractedBuildInfo(buildInfoExtractor.extract(null), buildInfoExtractor.getDeployableArtifact());
     }
 
-    private ArtifactoryBuildInfoClient getBuildInfoClient(String selectedServerUrl, Map<String, String> runnerParams,
-            BuildProgressLogger logger) {
-        ArtifactoryBuildInfoClient infoClient =
-                new ArtifactoryBuildInfoClient(selectedServerUrl,
-                        runnerParams.get(RunnerParameterKeys.DEPLOYER_USERNAME),
-                        runnerParams.get(RunnerParameterKeys.DEPLOYER_PASSWORD),
-                        new TeamcityAgenBuildInfoLog(logger));
-        infoClient.setConnectionTimeout(Integer.parseInt(runnerParams.get(RunnerParameterKeys.TIMEOUT)));
+    private ArtifactoryBuildInfoClientBuilder getBuildInfoClient(String selectedServerUrl, Map<String, String> runnerParams, BuildProgressLogger logger) {
+        ArtifactoryBuildInfoClientBuilder builder = new ArtifactoryBuildInfoClientBuilder()
+                .setArtifactoryUrl(selectedServerUrl)
+                .setUsername(runnerParams.get(RunnerParameterKeys.DEPLOYER_USERNAME))
+                .setPassword(runnerParams.get(RunnerParameterKeys.DEPLOYER_PASSWORD))
+                .setLog(new TeamcityAgenBuildInfoLog(logger))
+                .setConnectionTimeout(Integer.parseInt(runnerParams.get(RunnerParameterKeys.TIMEOUT)));
 
         if (runnerParams.containsKey(PROXY_HOST)) {
+            ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+            proxyConfiguration.host = runnerParams.get(PROXY_USERNAME);
+            proxyConfiguration.port = Integer.parseInt(runnerParams.get(PROXY_PORT));
             if (StringUtils.isNotBlank(runnerParams.get(PROXY_USERNAME))) {
-                infoClient.setProxyConfiguration(runnerParams.get(PROXY_HOST),
-                        Integer.parseInt(runnerParams.get(PROXY_PORT)), runnerParams.get(PROXY_USERNAME),
-                        runnerParams.get(PROXY_PASSWORD));
-            } else {
-                infoClient.setProxyConfiguration(runnerParams.get(PROXY_HOST),
-                        Integer.parseInt(runnerParams.get(PROXY_PORT)));
+                proxyConfiguration.username = runnerParams.get(PROXY_USERNAME);
+                proxyConfiguration.password = runnerParams.get(PROXY_PASSWORD);
             }
+            builder.setProxyConfiguration(proxyConfiguration);
         }
-        return infoClient;
+        return builder;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.version>${project.version}</plugin.version>
         <teamcity.version>2017.1</teamcity.version>
-        <build.info.version>2.11.3</build.info.version>
-        <build.info.maven3.version>2.11.1</build.info.maven3.version>
-        <build.info.gradle.version>4.7.5</build.info.gradle.version>
-        <build.info.ivy.version>2.11.1</build.info.ivy.version>
+        <build.info.version>2.13.0</build.info.version>
+        <build.info.maven3.version>2.13.0</build.info.maven3.version>
+        <build.info.gradle.version>4.9.0</build.info.gradle.version>
+        <build.info.ivy.version>2.13.0</build.info.ivy.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
* Upgrade build-info extractors (except Gradle) to 2.13.0 and Gradle extractor to 4.9.0.
* Fix BuildInfoExtractor APIs.
* Generic - Use ArtifactoryBuildInfoClientBuilder instead of ArtifactoryBuildInfoClient to support the new concurrency mechanism in build-info.