### PR TITLE
Feature: Allow skipping of upload for personal builds

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/GenericBuildInfoExtractor.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/GenericBuildInfoExtractor.java
@@ -63,8 +63,10 @@ public class GenericBuildInfoExtractor extends BaseBuildInfoExtractor<Object> {
         String uploadSpec = getUploadSpec();
         if (StringUtils.isEmpty(uploadSpec)) {
             return;
-        } else if (isUploadSkipped()) {
-            logger.message("Don't upload. Skipping upload on personal build is enabled!");
+        }
+
+        if (shouldSkipUpload()) {
+            logger.message("Skipping files upload to Artifactory. This job is configured to skip uploading files for personal builds.");
             return;
         }
 
@@ -76,16 +78,13 @@ public class GenericBuildInfoExtractor extends BaseBuildInfoExtractor<Object> {
         }
     }
 
-    private boolean isTeamCityPrivateBuild() {
-        Map<String,String> buildParameters =  runnerContext.getBuildParameters().getAllParameters();
-        if(buildParameters.containsKey(ConstantValues.PROP_PERSONAL_BUILD)){
-            return buildParameters.get(ConstantValues.PROP_PERSONAL_BUILD).equals("true");
-        }
-        return false;
+    private boolean isPrivateBuild() {
+        Map<String, String> buildParameters = runnerContext.getBuildParameters().getAllParameters();
+        return "true".equals(buildParameters.get(ConstantValues.PROP_PERSONAL_BUILD));
     }
 
-    private boolean isUploadSkipped() {
-        return isTeamCityPrivateBuild() && Boolean.parseBoolean(runnerParams.get(RunnerParameterKeys.UPLOAD_SKIP_ON_PERSONAL_BUILD));
+    private boolean shouldSkipUpload() {
+        return isPrivateBuild() && Boolean.parseBoolean(runnerParams.get(RunnerParameterKeys.UPLOAD_SKIP_ON_PERSONAL_BUILD));
     }
 
     private String getUploadSpec() throws IOException {

--- a/common/src/main/java/org/jfrog/teamcity/common/ConstantValues.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/ConstantValues.java
@@ -71,6 +71,8 @@ public class ConstantValues {
 
     public static final String SPEC_FILE_SOURCE = "File";
 
+    public static final String PROP_PERSONAL_BUILD = "system.build.is.personal";
+
     public static String pluginVersion;
 
     //retrieve the plugin version

--- a/common/src/main/java/org/jfrog/teamcity/common/RunnerParameterKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/RunnerParameterKeys.java
@@ -77,6 +77,7 @@ public class RunnerParameterKeys {
     public final static String DOWNLOAD_SPEC_SOURCE = PREFIX + "downloadSpecSource";
     public final static String DOWNLOAD_SPEC = PREFIX + "downloadSpec";
     public final static String DOWNLOAD_SPEC_FILE_PATH = PREFIX + "downloadSpecFilePath";
+    public final static String UPLOAD_SKIP_ON_PERSONAL_BUILD = PREFIX + "uploadSkipPersonalBuild";
     public final static String UPLOAD_SPEC_SOURCE = PREFIX + "uploadSpecSource";
     public final static String UPLOAD_SPEC = PREFIX + "uploadSpec";
     public final static String UPLOAD_SPEC_FILE_PATH = PREFIX + "uploadSpecFilePath";

--- a/server/src/main/resources/buildServerResources/common/genericSpecsEdit.jsp
+++ b/server/src/main/resources/buildServerResources/common/genericSpecsEdit.jsp
@@ -123,6 +123,17 @@
     </td>
 </tr>
 
+<tr class="noBorder" id="uploadSkipPersonalBuild.container">
+    <th>
+        <label for="org.jfrog.artifactory.selectedDeployableServer.uploadSkipPersonalBuild">
+            Skip upload for personal builds:
+        </label>
+    </th>
+    <td>
+        <props:checkboxProperty name="org.jfrog.artifactory.selectedDeployableServer.uploadSkipPersonalBuild"/>
+    </td>
+</tr>
+
 <script>
     BS.artifactory.setUseSpecsForGenerics('${shouldDisplay}');
 </script>

--- a/server/src/main/resources/buildServerResources/common/genericSpecsEdit.jsp
+++ b/server/src/main/resources/buildServerResources/common/genericSpecsEdit.jsp
@@ -126,7 +126,7 @@
 <tr class="noBorder" id="uploadSkipPersonalBuild.container">
     <th>
         <label for="org.jfrog.artifactory.selectedDeployableServer.uploadSkipPersonalBuild">
-            Skip upload for personal builds:
+            Skip upload on personal builds:
         </label>
     </th>
     <td>


### PR DESCRIPTION
TeamCity supports `personal builds`. In some cases we don't want to upload files from such a personal builds. 