### PR TITLE
Add support for running Docker in Docker gradle builds.

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/gradle/GradleBuildInfoAgentListener.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/gradle/GradleBuildInfoAgentListener.java
@@ -132,7 +132,7 @@ public class GradleBuildInfoAgentListener extends ArtifactoryAgentLifeCycleAdapt
             }
             taskBuilder.append(ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME);
             runnerContext.addRunnerParameter("ui.gradleRunner.gradle.tasks.names", taskBuilder.toString());
-            File tempPropFile = File.createTempFile("buildInfo", "properties");
+            File tempPropFile = File.createTempFile("buildInfo", "properties", build.getBuildTempDirectory());
             clientConf.setPropertiesFile(tempPropFile.getCanonicalPath());
             clientConf.persistToPropertiesFile();
             commandBuilder.append("-D").append(BuildInfoConfigProperties.PROP_PROPS_FILE).append("=").
@@ -174,7 +174,7 @@ public class GradleBuildInfoAgentListener extends ArtifactoryAgentLifeCycleAdapt
             return null;
         }
 
-        File tempInitScript = File.createTempFile("artifactory.init.script", "gradle");
+        File tempInitScript = File.createTempFile("artifactory.init.script", "gradle", build.getBuildTempDirectory());
         FileUtils.writeStringToFile(tempInitScript, scriptTemplate, "utf-8");
         return tempInitScript;
     }

--- a/agent/src/test/java/org/jfrog/teamcity/agent/gradle/GradleBuildInfoAgentListenerTest.java
+++ b/agent/src/test/java/org/jfrog/teamcity/agent/gradle/GradleBuildInfoAgentListenerTest.java
@@ -174,10 +174,14 @@ public class GradleBuildInfoAgentListenerTest {
         AgentRunningBuild agentRunningBuild = EasyMock.createMock(AgentRunningBuild.class);
         EasyMock.expect(agentRunningBuild.getBuildLogger())
                 .andReturn(EasyMock.createMock(BuildProgressLogger.class)).anyTimes();
+
         File tempDir = Files.createTempDir();
+        File buildTempDir = Files.createTempDir();
+
         new File(tempDir, ConstantValues.GRADLE_PROPERTIES_FILE_NAME).createNewFile();
         EasyMock.expect(runner.getWorkingDirectory()).andReturn(tempDir);
         EasyMock.expect(agentRunningBuild.getSharedConfigParameters()).andReturn(Maps.<String, String>newHashMap());
+        EasyMock.expect(agentRunningBuild.getBuildTempDirectory()).andReturn(buildTempDir).times(2);
 
         BuildAgentConfiguration buildAgentConfiguration = EasyMock.createMock(BuildAgentConfiguration.class);
         EasyMock.expect(buildAgentConfiguration.getAgentPluginsDirectory()).andReturn(Files.createTempDir());


### PR DESCRIPTION
This PR adds support for running Gradle builds inside a Docker in Docker environment, known inside TeamCity as Docker wrapper.

The orginal code used File.createTempFile which puts the file inside the agents `globalTemp` folder. This folder by default is not added as a volume to the Docker wrapper container that TeamCity spawns. One could mount the volume for this directory manually but since this is a build specific temporary file, it would be better if the plugin created its temp files in the for the build specific temporary directory, since these get mounted into the docker container.

I updated the unit tests to show that the code is still working. Additionally this PR is under testing inside our own TeamCity instance and is working fine.

Greets,
Orion (LDTTeam)