### PR TITLE
Fix: Ensures triggers are unique

### DIFF
--- a/server/src/main/java/org/jfrog/teamcity/server/trigger/ArtifactoryPolledBuildTrigger.java
+++ b/server/src/main/java/org/jfrog/teamcity/server/trigger/ArtifactoryPolledBuildTrigger.java
@@ -166,6 +166,6 @@ public class ArtifactoryPolledBuildTrigger extends PolledBuildTrigger {
     private String getUniqueTriggerId(PolledTriggerContext context) {
         String triggerId = context.getTriggerDescriptor().getId();
         String serverUrlId = context.getTriggerDescriptor().getProperties().get(TriggerParameterKeys.URL_ID);
-        return context.getBuildType().getExtendedName() + ":" + triggerId + ":" + serverUrlId;
+        return context.getBuildType().getFullName() + ":" + triggerId + ":" + serverUrlId;
     }
 }


### PR DESCRIPTION
In our TeamCity setup - we have multiple projects for different generations of our product - but with the same build configurations for each generation. This means that the IDs of the Artifactory triggers on our build configurations are not unique when using `getExtendedName()` - since this only combines the names of the build configuration itself and its parent. Whereas using `getFullName()` combines the names of all the build configurations in the tree from the **Root** project to the actual build configuration with the trigger.