### PR TITLE
Fix showing a build url when nothing is selected

### DIFF
--- a/server/src/main/resources/buildServerResources/maven/mavenRunTypeExtensionEdit.jsp
+++ b/server/src/main/resources/buildServerResources/maven/mavenRunTypeExtensionEdit.jsp
@@ -53,7 +53,7 @@
                 $('org.jfrog.artifactory.selectedDeployableServer.deployArtifacts').checked = false;
                 $('org.jfrog.artifactory.selectedDeployableServer.deployIncludePatterns').value = '';
                 $('org.jfrog.artifactory.selectedDeployableServer.deployExcludePatterns').value = '';
-                $('org.jfrog.artifactory.selectedDeployableServer.publishBuildInfo').checked = true;
+                $('org.jfrog.artifactory.selectedDeployableServer.publishBuildInfo').checked = false;
                 $('org.jfrog.artifactory.selectedDeployableServer.includeEnvVars').checked = false;
                 $('org.jfrog.artifactory.selectedDeployableServer.envVarsIncludePatterns').value = '';
                 $('org.jfrog.artifactory.selectedDeployableServer.envVarsExcludePatterns').value = '*password*,*secret*';


### PR DESCRIPTION
Without this fix when no artifactory url is selected the property `org.jfrog.artifactory.selectedDeployableServer.publishBuildInfo` is set to `true`, which results in the generation of an invalid build info url.