### PR TITLE
Fix Security Violation

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/docker/ArtifactoryDockerBuildProcess.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/docker/ArtifactoryDockerBuildProcess.java
@@ -1,7 +1,6 @@
 package org.jfrog.teamcity.agent.docker;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimaps;
+import org.jfrog.build.api.multiMap.ListMultimap;
 import jetbrains.buildServer.agent.AgentRunningBuild;
 import jetbrains.buildServer.agent.BuildFinishedStatus;
 import jetbrains.buildServer.agent.BuildRunnerContext;
@@ -78,7 +77,7 @@ public class ArtifactoryDockerBuildProcess extends BaseArtifactoryBuildProcess {
         String password = runnerParameters.get(RunnerParameterKeys.DEPLOYER_PASSWORD);
 
         return new DockerPush(buildInfoClientBuilder, imageName, host,
-                ArrayListMultimap.create(Multimaps.forMap(BuildInfoUtils.getCommonArtifactPropertiesMap(runnerParameters, context))),
+                new ListMultimap<>(BuildInfoUtils.getCommonArtifactPropertiesMap(runnerParameters, context)),
                 targetRepo, userName, password, buildInfoLog, environmentVariables).execute();
     }
 

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
@@ -64,7 +64,7 @@ public class AgentUtils {
         UsageReporter usageReporter = new UsageReporter("teamcity-artifactory-plugin/" + pluginVersion, featureIdArray);
         try {
             usageReporter.reportUsage(serverConfig.getUrl(), serverConfig.getUsername(), serverConfig.getPassword(),
-                    "", getProxyConfiguration(runnerParameters), log);
+                    "", getProxyConfiguration(runnerParameters), null, log);
             log.info("Usage info sent successfully.");
         } catch (Exception ex) {
             log.info("Failed sending usage report to Artifactory: " + ex);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
@@ -10,6 +10,7 @@ import jetbrains.buildServer.agent.impl.BuildRunnerContextImpl;
 import jetbrains.buildServer.parameters.ValueResolver;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.jfrog.teamcity.agent.util.TeamcityAgenBuildInfoLog;
 import org.jfrog.build.extractor.ci.BuildInfoFields;
 import org.jfrog.build.extractor.ci.BuildRetention;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
@@ -200,7 +201,8 @@ public abstract class ArtifactoryClientConfigurationBuilder {
     private static void addMatrixParamProperties(BuildRunnerContext runnerContext,
                                                  ArtifactoryClientConfiguration clientConf) {
         Properties fileAndSystemProperties =
-                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties());
+                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties(),
+                        new TeamcityAgenBuildInfoLog(runnerContext.getBuild().getBuildLogger()));
         Properties filteredMatrixParams = BuildInfoExtractorUtils
                 .filterDynamicProperties(fileAndSystemProperties, BuildInfoExtractorUtils.MATRIX_PARAM_PREDICATE);
         Enumeration<Object> propertyKeys = filteredMatrixParams.keys();

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
@@ -75,7 +75,7 @@ public abstract class ArtifactoryClientConfigurationBuilder {
         addBuildRetentionIfNeeded(buildLogger, clientConf, runnerParameters);
         ValueResolver repositoryResolver = runnerContext.getParametersResolver();
         addClientProperties(runnerParameters, repositoryResolver, clientConf);
-        addMatrixParamProperties(runnerContext, clientConf);
+        addMatrixParamProperties(runnerContext, clientConf, new TeamcityAgenBuildInfoLog(buildLogger));
         addEnvVars(runnerContext, clientConf);
         return clientConf;
     }
@@ -199,10 +199,10 @@ public abstract class ArtifactoryClientConfigurationBuilder {
     }
 
     private static void addMatrixParamProperties(BuildRunnerContext runnerContext,
-                                                 ArtifactoryClientConfiguration clientConf) {
+                                                 ArtifactoryClientConfiguration clientConf,
+                                                 org.jfrog.build.api.util.Log log) {
         Properties fileAndSystemProperties =
-                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties(),
-                        new TeamcityAgenBuildInfoLog(runnerContext.getBuild().getBuildLogger()));
+                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties(), log);
         Properties filteredMatrixParams = BuildInfoExtractorUtils
                 .filterDynamicProperties(fileAndSystemProperties, BuildInfoExtractorUtils.MATRIX_PARAM_PREDICATE);
         Enumeration<Object> propertyKeys = filteredMatrixParams.keys();

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.version>${project.version}</plugin.version>
         <teamcity.version>2025.07</teamcity.version>
-        <build.info.version>2.38.1</build.info.version>
+        <build.info.version>2.43.6</build.info.version>
         <build.info.gradle.version>4.30.1</build.info.gradle.version>
     </properties>
 
@@ -113,12 +113,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.17.2</version>
+                <version>2.18.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.17.2</version>
+                <version>2.18.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -563,62 +563,62 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-socks</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.125.Final-linux-x86_64</version>
+                <version>4.1.130.Final-linux-x86_64</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.1.125.Final</version>
+                <version>4.1.130.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>4.1.125.Final-osx-x86_64</version>
+                <version>4.1.130.Final-osx-x86_64</version>
             </dependency>
             <!-- Override vulnerable OWASP HTML sanitizer -->
             <dependency>

--- a/server/src/main/java/org/jfrog/teamcity/server/runner/BaseRunTypeConfigPropertiesProcessor.java
+++ b/server/src/main/java/org/jfrog/teamcity/server/runner/BaseRunTypeConfigPropertiesProcessor.java
@@ -17,7 +17,7 @@
 package org.jfrog.teamcity.server.runner;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
+import org.jfrog.build.api.multiMap.Multimap;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import org.apache.commons.lang3.BooleanUtils;


### PR DESCRIPTION
**Title:** Fix security audit violations - upgrade jackson, netty, build-info

**Description:**
Upgrade vulnerable direct dependencies to resolve `jf audit` security violations.

- jackson-core/databind: 2.17.2 → 2.18.6
- netty (all modules): 4.1.125.Final → 4.1.130.Final
- build-info-extractor: 2.38.1 → 2.43.6
