### PR TITLE
Move plugin to Java 21 and target TeamCity 2025.11 SDK

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,46 @@ jobs:
 
       - name: Run tests
         run: mvn -V -B -U --no-transfer-progress clean verify
+
+  E2E-Build-Publish:
+    name: E2E build & publish (TeamCity 2025.11 -> Artifactory on JDK 21)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Build plugin
+        run: mvn -V -B -U --no-transfer-progress -DskipTests -pl assembly -am package
+
+      # Full build-and-publish E2E: the script stands up Artifactory Pro (with
+      # the RTLIC license) + PostgreSQL and a TeamCity 2025.11 server + agent,
+      # runs a real build through the plugin, and verifies the artifact and
+      # build-info actually land in Artifactory. The plugin authenticates with
+      # USER_NAME / PASSWORD. If the RTLIC secret is unavailable (e.g. on fork
+      # PRs), the script falls back to publishing into an existing generic repo.
+      - name: E2E build-and-publish test
+        env:
+          TEAMCITY_IMAGE: "jetbrains/teamcity-server:2025.11"
+          TEAMCITY_AGENT_IMAGE: "jetbrains/teamcity-agent:2025.11"
+          ARTIFACTORY_IMAGE: "releases-docker.jfrog.io/jfrog/artifactory-pro:latest"
+          ARTIFACTORY_LICENSE: ${{ secrets.RTLIC }}
+          # Runtime credentials the plugin uses to authenticate to Artifactory.
+          ARTIFACTORY_USER: ${{ secrets.USER_NAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.PASSWORD }}
+          # Bootstrap admin for the freshly spun-up Artifactory container.
+          ART_ADMIN_USER: ${{ secrets.ART_ADMIN_USER }}
+          ART_ADMIN_PW: ${{ secrets.ART_ADMIN_PW }}
+          # TeamCity admin created on the throwaway server (reuses the same secrets).
+          TC_ADMIN_USER: ${{ secrets.USER_NAME }}
+          TC_ADMIN_PASSWORD: ${{ secrets.PASSWORD }}
+          TC_PORT: "8111"
+          STARTUP_TIMEOUT: "900"
+        run: ci/e2e/build-publish-e2e.sh

--- a/Third-Parties-Usage.html
+++ b/Third-Parties-Usage.html
@@ -6,10 +6,10 @@
     <title>3rd party licenses</title></head>
 <body>
 <div>
-    <div align="center"><b>Teamcity Artifactory Plugin- Third Parties - Usage - About Box</b></div>
+    <div align="center"><b>Teamcity Artifactory Plugin - Third Parties - Usage - About Box</b></div>
     <p/>
-    <b>This software includes the following UNMODIFIED third party software:</b>
-
+    <b>This software bundles the following UNMODIFIED third party software
+        (46 projects / 128 artifacts):</b>
     <p/>
     <table border="1">
         <tr>
@@ -18,126 +18,277 @@
             <td width="33%"><b>Licensed under</b></td>
         </tr>
         <tr>
-            <td>XStream Core</td>
-            <td><p><a href=http://xstream.codehaus.org>http://xstream.codehaus.org</a></p></td>
-            <td>BSD License <p><a href=http://www.opensource.org/licenses/bsd-license.php>http://www.opensource.org/licenses/bsd-license.php</a>
-            </p></td>
-        </tr>
-        <tr>
-            <td>Commons Codec</td>
-            <td><p><a href=http://commons.apache.org/codec/>http://commons.apache.org/codec/</a></p></td>
-            <td>Apache License, Version 2.0 <p><a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-            </p></td>
-        </tr>
-
-        <tr>
-            <td>Apache HttpComponents Core</td>
-            <td><p><a href=http://hc.apache.org/httpcomponents-core/>http://hc.apache.org/httpcomponents-core/</a>
-            </p></td>
+            <td>JFrog Build Info</td>
+            <td><p><a href="https://github.com/jfrog/build-info">https://github.com/jfrog/build-info</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Apache HttpComponents Client</td>
-            <td><p><a href=http://hc.apache.org/httpcomponents-client/>http://hc.apache.org/httpcomponents-client/</a>
-            </p></td>
+            <td>JFrog File Specs (Java)</td>
+            <td><p><a href="https://github.com/jfrog/jfrog-client-go">https://github.com/jfrog/jfrog-client-go</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Commons IO</td>
-            <td><p><a href=http://commons.apache.org/io/>http://commons.apache.org/io/</a></p></td>
+            <td>FasterXML Jackson</td>
+            <td><p><a href="https://github.com/FasterXML/jackson">https://github.com/FasterXML/jackson</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Commons Lang</td>
-            <td><p><a href=http://commons.apache.org/lang/>http://commons.apache.org/lang/</a></p>
-            </td>
+            <td>Netty</td>
+            <td><p><a href="https://netty.io">https://netty.io</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Commons Logging</td>
-            <td><p><a href=http://commons.apache.org/logging/>http://commons.apache.org/logging/</a>
-            </p></td>
+            <td>docker-java</td>
+            <td><p><a href="https://github.com/docker-java/docker-java">https://github.com/docker-java/docker-java</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Google Guava Library</td>
-            <td><p><a href=http://code.google.com/p/guava-libraries/>http://code.google.com/p/guava-libraries/</a>
-            </p></td>
+            <td>Google Guava</td>
+            <td><p><a href="https://github.com/google/guava">https://github.com/google/guava</a></p></td>
             <td>Apache License, Version 2.0
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
-
         <tr>
-            <td>Jackson</td>
-            <td><p><a href=http://jackson.codehaus.org/>http://jackson.codehaus.org/</a></p></td>
+            <td>Google Guice</td>
+            <td><p><a href="https://github.com/google/guice">https://github.com/google/guice</a></p></td>
             <td>Apache License, Version 2.0
-
-                <p>
-                    <a href=http://www.apache.org/licenses/LICENSE-2.0>http://www.apache.org/licenses/LICENSE-2.0</a>
-                </p></td>
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Xml Pull Parser 3rd Edition (XPP3)</td>
-            <td><p><a
-                    href=http://www.extreme.indiana.edu/xgws/xsoap/xpp/>http://www.extreme.indiana.edu/xgws/xsoap/xpp/</a>
-            </p></td>
-            <td>LICENSE FOR THE Extreme! Lab PullParser
-
-                <p><a href=http://www.extreme.indiana.edu/xgws/xsoap/xpp/download/PullParser2/LICENSE.txt>http://www.extreme.indiana.edu/xgws/xsoap/xpp/download/PullParser2/LICENSE.txt</a>
-                </p></td>
+            <td>Google Error Prone Annotations</td>
+            <td><p><a href="https://errorprone.info/">https://errorprone.info/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>JDom</td>
-            <td><p><a href=http://www.jdom.org/>http://www.jdom.org/</a></p></td>
-            <td>JDOM is available under an Apache-style open source license
-
-                <p>
-                    <a href=http://www.jdom.org/docs/faq.html#a0030>http://www.jdom.org/docs/faq.html#a0030</a>
-                </p>
-
-                Copyright (C) 2000-2004 Jason Hunter &amp; Brett McLaughlin.<br> <a
-                        href=http://vmgump.apache.org/gump/public-jars/org.jdom/jars/LICENSE.txt>http://vmgump.apache.org/gump/public-jars/org.jdom/jars/LICENSE.txt</a>
-            </td>
+            <td>FindBugs JSR-305</td>
+            <td><p><a href="https://github.com/findbugsproject/findbugs">https://github.com/findbugsproject/findbugs</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>Servlet API</td>
-            <td><p><a href="http://jcp.org/aboutJava/communityprocess/mrel/jsr154/index2.html">http://jcp.org/aboutJava/communityprocess/mrel/jsr154/index2.html</a>
-            </p></td>
-            <td>License Agreement for Java Servlet 2.5 Maintenance Release 2
-                <p>
-                    <a href="https://cds.sun.com/is-bin/INTERSHOP.enfinity/WFS/CDS-CDS_JCP-Site/en_US/-/USD/ViewLicense-Start">https://cds.sun.com/is-bin/INTERSHOP.enfinity/WFS/CDS-CDS_JCP-Site/en_US/-/USD/ViewLicense-Start</a>
-                </p></td>
+            <td>J2ObjC Annotations</td>
+            <td><p><a href="https://github.com/google/j2objc">https://github.com/google/j2objc</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
         </tr>
         <tr>
-            <td>AspectJWeaver</td>
-            <td><p><a href="http://www.eclipse.org/aspectj/index.php">http://www.eclipse.org/aspectj/index.php</a>
-            </p></td>
-            <td>Eclipse Public License - v 1.0
-                <p>
-                    <a href="http://eclipse.org/legal/epl-v10.html">http://eclipse.org/legal/epl-v10.html</a>
-                </p></td>
+            <td>Apache Commons</td>
+            <td><p><a href="https://commons.apache.org/">https://commons.apache.org/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Apache HttpComponents</td>
+            <td><p><a href="https://hc.apache.org/">https://hc.apache.org/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Apache Ivy</td>
+            <td><p><a href="https://ant.apache.org/ivy/">https://ant.apache.org/ivy/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Apache Maven &amp; Maven Artifact Resolver</td>
+            <td><p><a href="https://maven.apache.org/">https://maven.apache.org/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Apache XBean</td>
+            <td><p><a href="https://geronimo.apache.org/xbean/">https://geronimo.apache.org/xbean/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Apache MINA SSHD</td>
+            <td><p><a href="https://mina.apache.org/sshd-project/">https://mina.apache.org/sshd-project/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Codehaus Plexus</td>
+            <td><p><a href="https://codehaus-plexus.github.io/">https://codehaus-plexus.github.io/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>Eclipse Aether</td>
+            <td><p><a href="https://www.eclipse.org/aether/">https://www.eclipse.org/aether/</a></p></td>
+            <td>Eclipse Public License 1.0
+                <p><a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Eclipse Sisu</td>
+            <td><p><a href="https://www.eclipse.org/sisu/">https://www.eclipse.org/sisu/</a></p></td>
+            <td>Eclipse Public License 1.0
+                <p><a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Eclipse GlassFish HK2</td>
+            <td><p><a href="https://github.com/eclipse-ee4j/glassfish-hk2">https://github.com/eclipse-ee4j/glassfish-hk2</a></p></td>
+            <td>Eclipse Public License 2.0 / GPL v2 with Classpath Exception
+                <p><a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a></p></td>
+        </tr>
+        <tr>
+            <td>Eclipse Jersey</td>
+            <td><p><a href="https://eclipse-ee4j.github.io/jersey/">https://eclipse-ee4j.github.io/jersey/</a></p></td>
+            <td>Eclipse Public License 2.0 / GPL v2 with Classpath Exception
+                <p><a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a></p></td>
+        </tr>
+        <tr>
+            <td>Jakarta Annotations API</td>
+            <td><p><a href="https://github.com/eclipse-ee4j/common-annotations-api">https://github.com/eclipse-ee4j/common-annotations-api</a></p></td>
+            <td>Eclipse Public License 2.0 / GPL v2 with Classpath Exception
+                <p><a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a></p></td>
+        </tr>
+        <tr>
+            <td>Jakarta RESTful WS API</td>
+            <td><p><a href="https://github.com/eclipse-ee4j/jaxrs-api">https://github.com/eclipse-ee4j/jaxrs-api</a></p></td>
+            <td>Eclipse Public License 2.0 / GPL v2 with Classpath Exception
+                <p><a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a></p></td>
+        </tr>
+        <tr>
+            <td>Jakarta Activation API</td>
+            <td><p><a href="https://github.com/eclipse-ee4j/jaf">https://github.com/eclipse-ee4j/jaf</a></p></td>
+            <td>Eclipse Distribution License 1.0 (BSD-style)
+                <p><a href="https://www.eclipse.org/org/documents/edl-v10.php">https://www.eclipse.org/org/documents/edl-v10.php</a></p></td>
+        </tr>
+        <tr>
+            <td>Jakarta XML Binding API</td>
+            <td><p><a href="https://github.com/eclipse-ee4j/jaxb-api">https://github.com/eclipse-ee4j/jaxb-api</a></p></td>
+            <td>Eclipse Distribution License 1.0 (BSD-style)
+                <p><a href="https://www.eclipse.org/org/documents/edl-v10.php">https://www.eclipse.org/org/documents/edl-v10.php</a></p></td>
+        </tr>
+        <tr>
+            <td>javax.inject</td>
+            <td><p><a href="https://github.com/javax-inject/javax-inject">https://github.com/javax-inject/javax-inject</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>AOP Alliance</td>
+            <td><p><a href="http://aopalliance.sourceforge.net/">http://aopalliance.sourceforge.net/</a></p></td>
+            <td>Public Domain</td>
+        </tr>
+        <tr>
+            <td>Bouncy Castle</td>
+            <td><p><a href="https://www.bouncycastle.org/">https://www.bouncycastle.org/</a></p></td>
+            <td>Bouncy Castle License (MIT-style)
+                <p><a href="https://www.bouncycastle.org/licence.html">https://www.bouncycastle.org/licence.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Checker Framework Qualifiers</td>
+            <td><p><a href="https://checkerframework.org/">https://checkerframework.org/</a></p></td>
+            <td>MIT License
+                <p><a href="https://opensource.org/licenses/MIT">https://opensource.org/licenses/MIT</a></p></td>
+        </tr>
+        <tr>
+            <td>SLF4J</td>
+            <td><p><a href="https://www.slf4j.org/">https://www.slf4j.org/</a></p></td>
+            <td>MIT License
+                <p><a href="https://opensource.org/licenses/MIT">https://opensource.org/licenses/MIT</a></p></td>
+        </tr>
+        <tr>
+            <td>OW2 ASM</td>
+            <td><p><a href="https://asm.ow2.io/">https://asm.ow2.io/</a></p></td>
+            <td>BSD 3-Clause License
+                <p><a href="https://opensource.org/licenses/BSD-3-Clause">https://opensource.org/licenses/BSD-3-Clause</a></p></td>
+        </tr>
+        <tr>
+            <td>Java Native Access (JNA)</td>
+            <td><p><a href="https://github.com/java-native-access/jna">https://github.com/java-native-access/jna</a></p></td>
+            <td>Apache License, Version 2.0 or LGPL 2.1 (dual)
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>JZlib</td>
+            <td><p><a href="http://www.jcraft.com/jzlib/">http://www.jcraft.com/jzlib/</a></p></td>
+            <td>BSD License
+                <p><a href="https://opensource.org/licenses/BSD-2-Clause">https://opensource.org/licenses/BSD-2-Clause</a></p></td>
+        </tr>
+        <tr>
+            <td>jsch-agent-proxy</td>
+            <td><p><a href="https://github.com/ymnk/jsch-agent-proxy">https://github.com/ymnk/jsch-agent-proxy</a></p></td>
+            <td>BSD License
+                <p><a href="https://opensource.org/licenses/BSD-2-Clause">https://opensource.org/licenses/BSD-2-Clause</a></p></td>
+        </tr>
+        <tr>
+            <td>junixsocket</td>
+            <td><p><a href="https://kohlschutter.github.io/junixsocket/">https://kohlschutter.github.io/junixsocket/</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>ANTLR 3 Runtime</td>
+            <td><p><a href="https://www.antlr.org/">https://www.antlr.org/</a></p></td>
+            <td>ANTLR 3 BSD License
+                <p><a href="https://www.antlr.org/license.html">https://www.antlr.org/license.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Javassist</td>
+            <td><p><a href="https://www.javassist.org/">https://www.javassist.org/</a></p></td>
+            <td>Apache License 2.0 / LGPL 2.1 / MPL 1.1 (triple)
+                <p><a href="https://www.javassist.org/">https://www.javassist.org/</a></p></td>
+        </tr>
+        <tr>
+            <td>LZ4 / xxHash for Java</td>
+            <td><p><a href="https://github.com/lz4/lz4-java">https://github.com/lz4/lz4-java</a></p></td>
+            <td>Apache License, Version 2.0
+                <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p></td>
+        </tr>
+        <tr>
+            <td>JDOM</td>
+            <td><p><a href="http://www.jdom.org/">http://www.jdom.org/</a></p></td>
+            <td>JDOM License (Apache-style)
+                <p><a href="http://www.jdom.org/docs/faq.html#a0030">http://www.jdom.org/docs/faq.html#a0030</a></p></td>
+        </tr>
+        <tr>
+            <td>Hamcrest</td>
+            <td><p><a href="http://hamcrest.org/JavaHamcrest/">http://hamcrest.org/JavaHamcrest/</a></p></td>
+            <td>BSD 3-Clause License
+                <p><a href="https://opensource.org/licenses/BSD-3-Clause">https://opensource.org/licenses/BSD-3-Clause</a></p></td>
+        </tr>
+        <tr>
+            <td>JUnit 4</td>
+            <td><p><a href="https://junit.org/junit4/">https://junit.org/junit4/</a></p></td>
+            <td>Eclipse Public License 1.0
+                <p><a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Perforce P4Java</td>
+            <td><p><a href="https://www.perforce.com/">https://www.perforce.com/</a></p></td>
+            <td>Perforce Software License
+                <p><a href="https://www.perforce.com/">https://www.perforce.com/</a></p></td>
+        </tr>
+        <tr>
+            <td>Trilead SSH-2</td>
+            <td><p><a href="https://github.com/vdb/trilead-ssh2">https://github.com/vdb/trilead-ssh2</a></p></td>
+            <td>Trilead SSH-2 License (BSD-like)</td>
+        </tr>
+        <tr>
+            <td>SQLJet</td>
+            <td><p><a href="https://sqljet.com/">https://sqljet.com/</a></p></td>
+            <td>GNU General Public License v3
+                <p><a href="https://www.gnu.org/licenses/gpl-3.0.html">https://www.gnu.org/licenses/gpl-3.0.html</a></p></td>
+        </tr>
+        <tr>
+            <td>SVNKit</td>
+            <td><p><a href="https://svnkit.com/">https://svnkit.com/</a></p></td>
+            <td>TMate Open Source License
+                <p><a href="https://svnkit.com/license.html">https://svnkit.com/license.html</a></p></td>
+        </tr>
+        <tr>
+            <td>Sequence Library</td>
+            <td><p><a href="https://svnkit.com/">https://svnkit.com/</a></p></td>
+            <td>Sequence Library License (BSD-like)</td>
         </tr>
     </table>
     <p><br> <br> You can contact us via <b><i><a href="mailto:info@jfrog.org">info@jfrog.org</a></i></b> for any further

--- a/agent/src/main/java/org/jfrog/teamcity/agent/docker/ArtifactoryDockerBuildProcess.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/docker/ArtifactoryDockerBuildProcess.java
@@ -1,12 +1,11 @@
 package org.jfrog.teamcity.agent.docker;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimaps;
 import jetbrains.buildServer.agent.AgentRunningBuild;
 import jetbrains.buildServer.agent.BuildFinishedStatus;
 import jetbrains.buildServer.agent.BuildRunnerContext;
 import jetbrains.buildServer.agent.artifacts.ArtifactsWatcher;
 import org.jetbrains.annotations.NotNull;
+import org.jfrog.build.api.multiMap.ListMultimap;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -78,7 +77,7 @@ public class ArtifactoryDockerBuildProcess extends BaseArtifactoryBuildProcess {
         String password = runnerParameters.get(RunnerParameterKeys.DEPLOYER_PASSWORD);
 
         return new DockerPush(buildInfoClientBuilder, imageName, host,
-                ArrayListMultimap.create(Multimaps.forMap(BuildInfoUtils.getCommonArtifactPropertiesMap(runnerParameters, context))),
+                new ListMultimap<>(BuildInfoUtils.getCommonArtifactPropertiesMap(runnerParameters, context)),
                 targetRepo, userName, password, buildInfoLog, environmentVariables).execute();
     }
 

--- a/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCmd.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/release/vcs/git/GitCmd.java
@@ -51,9 +51,9 @@ public class GitCmd {
 
             int exitCode;
             if (timeout <= 0) {
-                exitCode = CommandLineExecutor.waitForProcess(process, errorGobbler, outputGobbler);
+                exitCode = CommandLineExecutor.waitForProcess(process, gitExe, errorGobbler, outputGobbler);
             } else {
-                exitCode = CommandLineExecutor.waitForProcess(process, errorGobbler, outputGobbler, timeout);
+                exitCode = CommandLineExecutor.waitForProcess(process, gitExe, errorGobbler, outputGobbler, timeout);
             }
 
             String out = outputGobbler.getReadString(Charsets.UTF_8);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
@@ -64,7 +64,7 @@ public class AgentUtils {
         UsageReporter usageReporter = new UsageReporter("teamcity-artifactory-plugin/" + pluginVersion, featureIdArray);
         try {
             usageReporter.reportUsage(serverConfig.getUrl(), serverConfig.getUsername(), serverConfig.getPassword(),
-                    "", getProxyConfiguration(runnerParameters), log);
+                    "", getProxyConfiguration(runnerParameters), null, log);
             log.info("Usage info sent successfully.");
         } catch (Exception ex) {
             log.info("Failed sending usage report to Artifactory: " + ex);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/AgentUtils.java
@@ -64,7 +64,7 @@ public class AgentUtils {
         UsageReporter usageReporter = new UsageReporter("teamcity-artifactory-plugin/" + pluginVersion, featureIdArray);
         try {
             usageReporter.reportUsage(serverConfig.getUrl(), serverConfig.getUsername(), serverConfig.getPassword(),
-                    "", getProxyConfiguration(runnerParameters), null, log);
+                    "", getProxyConfiguration(runnerParameters), null /* SSLContext: null == use default context */, log);
             log.info("Usage info sent successfully.");
         } catch (Exception ex) {
             log.info("Failed sending usage report to Artifactory: " + ex);

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/ArtifactoryClientConfigurationBuilder.java
@@ -200,7 +200,7 @@ public abstract class ArtifactoryClientConfigurationBuilder {
     private static void addMatrixParamProperties(BuildRunnerContext runnerContext,
                                                  ArtifactoryClientConfiguration clientConf) {
         Properties fileAndSystemProperties =
-                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties());
+                BuildInfoExtractorUtils.mergePropertiesWithSystemAndPropertyFile(new Properties(), clientConf.getLog());
         Properties filteredMatrixParams = BuildInfoExtractorUtils
                 .filterDynamicProperties(fileAndSystemProperties, BuildInfoExtractorUtils.MATRIX_PARAM_PREDICATE);
         Enumeration<Object> propertyKeys = filteredMatrixParams.keys();

--- a/agent/src/test/java/org/jfrog/teamcity/agent/util/BuildInfoByteEquivalenceTest.java
+++ b/agent/src/test/java/org/jfrog/teamcity/agent/util/BuildInfoByteEquivalenceTest.java
@@ -37,7 +37,9 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Guards the "non-negotiable": the Build-Info JSON produced by the bundled JFrog build-info
@@ -51,8 +53,15 @@ import static org.testng.Assert.assertNotNull;
  * timestamp formatting, etc.) fails the build.
  * <p>
  * Note on the 2.38.1 -> 2.43.9 upgrade specifically: 2.43.9 adds an {@code originalDeploymentRepo}
- * field to {@code Artifact}. Because the client serializes with {@code @JsonInclude(NON_NULL)},
- * the new field is omitted when unset and the output remains byte-identical - which this test proves.
+ * field to {@code Artifact}. Two things are covered here:
+ * <ul>
+ *   <li>{@link #buildInfoJsonIsByteEquivalentToGolden()} proves that when the field is unset it is
+ *       omitted (the client serializes with {@code @JsonInclude(NON_NULL)}), so the output stays
+ *       byte-identical to the 2.38.1 golden file.</li>
+ *   <li>{@link #originalDeploymentRepoSerializesWhenSet()} proves that when the field <i>is</i> set
+ *       it serializes under the expected {@code originalDeploymentRepo} key with the expected value -
+ *       i.e. the new capability the bump introduces actually works, not just its absence.</li>
+ * </ul>
  */
 public class BuildInfoByteEquivalenceTest {
 
@@ -64,6 +73,12 @@ public class BuildInfoByteEquivalenceTest {
     public void pinTimeZone() {
         // The 'started' timestamp is formatted with the JVM default time zone at build() time.
         // Pin to UTC so the assertion is stable regardless of the CI machine's time zone.
+        //
+        // NOTE: TimeZone.setDefault(...) mutates JVM-global state for the duration of this class.
+        // This relies on TestNG/Surefire running test classes sequentially (no parallel/threadCount
+        // configured in this repo). If parallel test execution is ever enabled, this must be
+        // reworked (e.g. per-test TimeZone injection) to avoid affecting other concurrently-running
+        // tests' timestamp formatting. @AfterClass restores the original zone.
         originalTimeZone = TimeZone.getDefault();
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
@@ -82,6 +97,48 @@ public class BuildInfoByteEquivalenceTest {
         assertEquals(actual, expected,
                 "Build-Info JSON output changed - the byte-equivalence guarantee is broken. " +
                         "If this change is intentional, regenerate " + GOLDEN_RESOURCE + " and review the diff.");
+    }
+
+    /**
+     * Covers the new capability the 2.43.9 bump introduces: when {@code originalDeploymentRepo} is
+     * set on an {@link Artifact}, it must serialize under the expected key with the expected value.
+     * The byte-equivalence test above only exercises the omitted-when-unset path; this asserts the
+     * field is actually emitted (right key, right value) when populated.
+     */
+    @Test
+    public void originalDeploymentRepoSerializesWhenSet() throws Exception {
+        Artifact withRepo = new ArtifactBuilder("demo-1.0.jar")
+                .type("jar")
+                .sha1("0123456789abcdef0123456789abcdef01234567")
+                .originalDeploymentRepo("libs-release-local")
+                .build();
+
+        Module module = new ModuleBuilder()
+                .id("org.example:demo:1.0")
+                .addArtifact(withRepo)
+                .build();
+
+        BuildInfo bi = new BuildInfoBuilder("teamcity-original-repo-fixture")
+                .number("42")
+                .startedDate(new Date(1600000000000L))
+                .addModule(module)
+                .build();
+
+        String json = BuildInfoExtractorUtils.buildInfoToJsonString(bi);
+
+        assertTrue(json.contains("\"originalDeploymentRepo\" : \"libs-release-local\""),
+                "Expected originalDeploymentRepo to serialize under its key when set, but got:\n" + json);
+    }
+
+    /**
+     * Complements the golden test: with {@code originalDeploymentRepo} unset, the key must be
+     * absent entirely (NON_NULL omission), which is what keeps the output byte-identical to 2.38.1.
+     */
+    @Test
+    public void originalDeploymentRepoOmittedWhenUnset() throws Exception {
+        String json = BuildInfoExtractorUtils.buildInfoToJsonString(buildDeterministicBuildInfo());
+        assertFalse(json.contains("originalDeploymentRepo"),
+                "Expected originalDeploymentRepo to be omitted when unset, but got:\n" + json);
     }
 
     /**

--- a/agent/src/test/java/org/jfrog/teamcity/agent/util/BuildInfoByteEquivalenceTest.java
+++ b/agent/src/test/java/org/jfrog/teamcity/agent/util/BuildInfoByteEquivalenceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2010 JFrog Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jfrog.teamcity.agent.util;
+
+import org.jfrog.build.extractor.BuildInfoExtractorUtils;
+import org.jfrog.build.extractor.builder.ArtifactBuilder;
+import org.jfrog.build.extractor.builder.BuildInfoBuilder;
+import org.jfrog.build.extractor.builder.DependencyBuilder;
+import org.jfrog.build.extractor.builder.ModuleBuilder;
+import org.jfrog.build.extractor.ci.Agent;
+import org.jfrog.build.extractor.ci.Artifact;
+import org.jfrog.build.extractor.ci.BuildAgent;
+import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.Dependency;
+import org.jfrog.build.extractor.ci.Module;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Guards the "non-negotiable": the Build-Info JSON produced by the bundled JFrog build-info
+ * Java client must stay <b>byte-for-byte identical</b> across client upgrades for a fixed input.
+ * <p>
+ * The golden resource {@code build-info/expected-build-info.json} was generated with the previous
+ * client (build-info 2.38.1) and verified to be byte-identical to the output of the current client
+ * (2.43.9). This test rebuilds the exact same deterministic {@link BuildInfo} with whatever client
+ * is on the classpath and asserts the serialized bytes match the golden file, so any future
+ * build-info bump that changes the serialized schema/format (field order, new non-null fields,
+ * timestamp formatting, etc.) fails the build.
+ * <p>
+ * Note on the 2.38.1 -> 2.43.9 upgrade specifically: 2.43.9 adds an {@code originalDeploymentRepo}
+ * field to {@code Artifact}. Because the client serializes with {@code @JsonInclude(NON_NULL)},
+ * the new field is omitted when unset and the output remains byte-identical - which this test proves.
+ */
+public class BuildInfoByteEquivalenceTest {
+
+    private static final String GOLDEN_RESOURCE = "/build-info/expected-build-info.json";
+
+    private TimeZone originalTimeZone;
+
+    @BeforeClass
+    public void pinTimeZone() {
+        // The 'started' timestamp is formatted with the JVM default time zone at build() time.
+        // Pin to UTC so the assertion is stable regardless of the CI machine's time zone.
+        originalTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @AfterClass
+    public void restoreTimeZone() {
+        if (originalTimeZone != null) {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void buildInfoJsonIsByteEquivalentToGolden() throws Exception {
+        String actual = BuildInfoExtractorUtils.buildInfoToJsonString(buildDeterministicBuildInfo());
+        String expected = readGolden();
+        assertEquals(actual, expected,
+                "Build-Info JSON output changed - the byte-equivalence guarantee is broken. " +
+                        "If this change is intentional, regenerate " + GOLDEN_RESOURCE + " and review the diff.");
+    }
+
+    /**
+     * Builds a deterministic BuildInfo using the same builder API the plugin uses
+     * ({@link BuildInfoBuilder}/{@link ModuleBuilder}/{@link ArtifactBuilder}/{@link DependencyBuilder}).
+     */
+    static BuildInfo buildDeterministicBuildInfo() {
+        Artifact art = new ArtifactBuilder("demo-1.0.jar")
+                .type("jar")
+                .sha1("0123456789abcdef0123456789abcdef01234567")
+                .sha256("0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff")
+                .md5("0123456789abcdef0123456789abcdef")
+                .remotePath("org/example/demo/1.0/demo-1.0.jar")
+                .build();
+
+        Dependency dep = new DependencyBuilder()
+                .id("com.google.guava:guava:32.0.1-jre")
+                .type("jar")
+                .sha1("89abcdef0123456789abcdef0123456789abcdef")
+                .sha256("ffffeeeeddddccccbbbbaaaa9999888877776666555544443333222211110000")
+                .md5("fedcba9876543210fedcba9876543210")
+                .addScope("compile")
+                .build();
+
+        Module module = new ModuleBuilder()
+                .id("org.example:demo:1.0")
+                .repository("libs-release-local")
+                .addArtifact(art)
+                .addDependency(dep)
+                .build();
+
+        BuildInfoBuilder b = new BuildInfoBuilder("teamcity-equiv-fixture")
+                .number("42")
+                .startedDate(new Date(1600000000000L)) // fixed instant: 2020-09-13T12:26:40Z
+                .durationMillis(123456L)
+                .url("http://teamcity/viewLog.html?buildId=42")
+                .principal("triggeredByUser")
+                .artifactoryPrincipal("deployerUser")
+                .artifactoryPluginVersion("2.11.x")
+                .agent(new Agent("TeamCity", "2025.11"))
+                .buildAgent(new BuildAgent("Maven", "3.9.12"))
+                .vcsRevision("abc123def456")
+                .vcsUrl("https://git.example.com/repo.git")
+                .addModule(module);
+
+        b.addProperty("buildInfo.env.ALPHA", "one");
+        b.addProperty("buildInfo.env.BETA", "two");
+        b.addProperty("buildInfo.env.GAMMA", "three");
+
+        return b.build();
+    }
+
+    private String readGolden() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream(GOLDEN_RESOURCE)) {
+            assertNotNull(in, "Missing golden resource " + GOLDEN_RESOURCE);
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/agent/src/test/resources/build-info/expected-build-info.json
+++ b/agent/src/test/resources/build-info/expected-build-info.json
@@ -1,0 +1,45 @@
+{
+  "properties" : {
+    "buildInfo.env.GAMMA" : "three",
+    "buildInfo.env.BETA" : "two",
+    "buildInfo.env.ALPHA" : "one"
+  },
+  "version" : "1.0.1",
+  "name" : "teamcity-equiv-fixture",
+  "number" : "42",
+  "buildAgent" : {
+    "name" : "Maven",
+    "version" : "3.9.12"
+  },
+  "agent" : {
+    "name" : "TeamCity",
+    "version" : "2025.11"
+  },
+  "started" : "2020-09-13T12:26:40.000+0000",
+  "durationMillis" : 123456,
+  "principal" : "triggeredByUser",
+  "artifactoryPrincipal" : "deployerUser",
+  "artifactoryPluginVersion" : "2.11.x",
+  "url" : "http://teamcity/viewLog.html?buildId=42",
+  "vcs" : [ ],
+  "modules" : [ {
+    "id" : "org.example:demo:1.0",
+    "repository" : "libs-release-local",
+    "artifacts" : [ {
+      "type" : "jar",
+      "sha1" : "0123456789abcdef0123456789abcdef01234567",
+      "sha256" : "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+      "md5" : "0123456789abcdef0123456789abcdef",
+      "name" : "demo-1.0.jar",
+      "path" : "org/example/demo/1.0/demo-1.0.jar"
+    } ],
+    "dependencies" : [ {
+      "type" : "jar",
+      "sha1" : "89abcdef0123456789abcdef0123456789abcdef",
+      "sha256" : "ffffeeeeddddccccbbbbaaaa9999888877776666555544443333222211110000",
+      "md5" : "fedcba9876543210fedcba9876543210",
+      "id" : "com.google.guava:guava:32.0.1-jre",
+      "scopes" : [ "compile" ]
+    } ]
+  } ]
+}

--- a/ci/e2e/build-publish-e2e.sh
+++ b/ci/e2e/build-publish-e2e.sh
@@ -1,0 +1,588 @@
+#!/usr/bin/env bash
+#
+# End-to-end build-and-publish test.
+#
+# This is the "real" end-to-end test: it stands up a full, working pipeline and
+# proves the freshly built Artifactory plugin can actually publish artifacts and
+# build-info to a live Artifactory from a real TeamCity build - all on the JDK
+# that TeamCity 2025.11 ships with (JDK 21).
+#
+# The flow, entirely automated:
+#   1. Bring up Artifactory (OSS + PostgreSQL) and create a generic repo.
+#      (Or point at an existing Artifactory via ARTIFACTORY_URL - see below.)
+#   2. Bring up a TeamCity 2025.11 server with the plugin pre-installed and the
+#      Artifactory connection pre-seeded (config/artifactory-config.xml).
+#   3. Drive the first-run wizard, create an admin (via the superuser token),
+#      bring up a TeamCity agent and authorize it.
+#   4. Create a project + build config with a build step that produces an
+#      artifact and uses the Artifactory plugin's generic upload spec, with
+#      "deploy artifacts" and "publish build-info" enabled.
+#   5. Run the build and wait for it to finish.
+#   6. Assert the build SUCCEEDED and verify - directly against Artifactory's
+#      REST API - that both the artifact and the build-info actually landed.
+#
+# Usage:
+#   ci/e2e/build-publish-e2e.sh [path-to-plugin.zip]
+#
+# Environment overrides:
+#   TEAMCITY_IMAGE     TeamCity server image   (default: jetbrains/teamcity-server:2025.11)
+#   TEAMCITY_AGENT_IMAGE                        (default: jetbrains/teamcity-agent:2025.11)
+#   TC_PORT            Host port for TeamCity   (default: 8111)
+#   STARTUP_TIMEOUT    Seconds to wait per stage(default: 600)
+#
+#   # Artifactory: by default this script brings up its own Artifactory OSS.
+#   # To test against an existing Artifactory instead, set ARTIFACTORY_URL and
+#   # the script will skip the bring-up (BYO mode):
+#   ARTIFACTORY_URL    e.g. http://my-artifactory:8081/artifactory (base, no trailing slash)
+#   ARTIFACTORY_REPO   generic repo to publish  (default: teamcity-generic-local)
+#   ARTIFACTORY_IMAGE  Pro image (self bring-up)(default: releases-docker.jfrog.io/jfrog/artifactory-pro:latest)
+#   POSTGRES_IMAGE     (self bring-up)          (default: postgres:14)
+#   BUILD_NAME         TeamCity build-type id     (default: e2e_Publish)
+#
+# Credentials - REQUIRED, no defaults (the CI workflow maps these from GitHub
+# repository secrets; the script fails fast if any are missing):
+#   ARTIFACTORY_USER / ARTIFACTORY_PASSWORD  runtime creds the plugin uses
+#   ART_ADMIN_USER   / ART_ADMIN_PW          bootstrap admin for a spun-up container
+#                                            (must match the image default admin creds)
+#   TC_ADMIN_USER    / TC_ADMIN_PASSWORD     TeamCity admin on the throwaway server
+#   ARTIFACTORY_LICENSE                      Artifactory Pro license (RTLIC), optional
+#
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+TEAMCITY_IMAGE="${TEAMCITY_IMAGE:-jetbrains/teamcity-server:2025.11}"
+TEAMCITY_AGENT_IMAGE="${TEAMCITY_AGENT_IMAGE:-jetbrains/teamcity-agent:2025.11}"
+TC_PORT="${TC_PORT:-8111}"
+STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-600}"
+
+ARTIFACTORY_IMAGE="${ARTIFACTORY_IMAGE:-releases-docker.jfrog.io/jfrog/artifactory-pro:latest}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:14}"
+ARTIFACTORY_REPO="${ARTIFACTORY_REPO:-teamcity-generic-local}"
+# TeamCity build-type id created for the test (project id 'e2e' + build 'publish').
+BUILD_NAME="${BUILD_NAME:-e2e_Publish}"
+
+# --- Credentials (must come from the environment / CI secrets) --------------
+# No inline defaults: these are sourced exclusively from environment variables,
+# which the CI workflow maps from GitHub repository secrets. Missing values
+# fail fast (see require_env below) rather than silently using weak defaults.
+#
+#   ARTIFACTORY_USER / ARTIFACTORY_PASSWORD  runtime creds the plugin uses
+#   ART_ADMIN_USER   / ART_ADMIN_PW          bootstrap admin for a spun-up container
+#   TC_ADMIN_USER    / TC_ADMIN_PASSWORD     TeamCity admin on the throwaway server
+#   ARTIFACTORY_LICENSE                      Artifactory Pro license (RTLIC)
+ARTIFACTORY_USER="${ARTIFACTORY_USER:-}"
+ARTIFACTORY_PASSWORD="${ARTIFACTORY_PASSWORD:-}"
+ART_ADMIN_USER="${ART_ADMIN_USER:-}"
+ART_ADMIN_PW="${ART_ADMIN_PW:-}"
+TC_ADMIN_USER="${TC_ADMIN_USER:-}"
+TC_ADMIN_PASSWORD="${TC_ADMIN_PASSWORD:-}"
+ARTIFACTORY_LICENSE="${ARTIFACTORY_LICENSE:-}"
+
+RUN_ID="$$"
+NET="jfrog-tc-e2e-net-${RUN_ID}"
+TC_SERVER="tc-e2e-server-${RUN_ID}"
+TC_AGENT="tc-e2e-agent-${RUN_ID}"
+ART_CONTAINER="art-e2e-${RUN_ID}"
+PG_CONTAINER="art-pg-${RUN_ID}"
+
+BASE_URL="http://localhost:${TC_PORT}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Fail fast if any required credential is missing from the environment. This
+# keeps all secrets out of the script and surfaces a misconfigured CI job with a
+# clear message instead of confusing auth failures deep in the run.
+require_env() {
+  local missing=0 name
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      echo "ERROR: required environment variable '${name}' is not set (provide it via CI secrets)." >&2
+      missing=1
+    fi
+  done
+  [[ ${missing} -eq 0 ]] || { echo "Aborting: missing required credentials." >&2; exit 1; }
+}
+
+# BYO-Artifactory mode: if ARTIFACTORY_URL is provided we do NOT bring one up,
+# and the runtime credentials are also used as the admin/bootstrap credentials.
+OWN_ARTIFACTORY=1
+if [[ -n "${ARTIFACTORY_URL:-}" ]]; then
+  OWN_ARTIFACTORY=0
+  ART_ADMIN_USER="${ARTIFACTORY_USER}"
+  ART_ADMIN_PW="${ARTIFACTORY_PASSWORD}"
+fi
+
+# Runtime + TeamCity admin creds are always required. Bootstrap admin creds are
+# only needed when we spin up our own Artifactory (in BYO mode they are derived
+# from the runtime creds above).
+require_env ARTIFACTORY_USER ARTIFACTORY_PASSWORD TC_ADMIN_USER TC_ADMIN_PASSWORD
+if [[ ${OWN_ARTIFACTORY} -eq 1 ]]; then
+  require_env ART_ADMIN_USER ART_ADMIN_PW
+fi
+
+# --- Locate the plugin zip --------------------------------------------------
+PLUGIN_ZIP="${1:-}"
+if [[ -z "${PLUGIN_ZIP}" ]]; then
+  PLUGIN_ZIP="$(ls -1 "${REPO_ROOT}"/target/teamcity-artifactory-plugin-*.zip 2>/dev/null | head -n1 || true)"
+fi
+if [[ -z "${PLUGIN_ZIP}" || ! -f "${PLUGIN_ZIP}" ]]; then
+  echo "ERROR: plugin zip not found. Build it first with:" >&2
+  echo "       mvn -B -DskipTests -pl assembly -am package" >&2
+  echo "       (or pass the path as the first argument)" >&2
+  exit 1
+fi
+echo "Using plugin zip:     ${PLUGIN_ZIP}"
+echo "Using TeamCity image: ${TEAMCITY_IMAGE}"
+
+# --- Workspace --------------------------------------------------------------
+WORK_DIR="$(mktemp -d)"
+DATA_DIR="${WORK_DIR}/datadir"
+LOGS_DIR="${WORK_DIR}/logs"
+COOKIE_JAR="${WORK_DIR}/cookies.txt"
+SERVER_LOG="${LOGS_DIR}/teamcity-server.log"
+mkdir -p "${DATA_DIR}/plugins" "${DATA_DIR}/config" "${LOGS_DIR}"
+cp "${PLUGIN_ZIP}" "${DATA_DIR}/plugins/"
+# The TeamCity container runs as uid 1000 (tcuser) and must be able to write to
+# the mounted datadir. These are throwaway temp dirs, so make them
+# world-writable to avoid "directory is not writeable" failures on CI runners.
+# The log dir is NOT bind-mounted (the container writes it owner-only as uid
+# 1000, unreadable from the host); we snapshot it via `docker cp` (refresh_log).
+chmod -R 777 "${WORK_DIR}"
+
+# --- Cleanup ----------------------------------------------------------------
+cleanup() {
+  local exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo ""
+    echo "======================== FAILURE DIAGNOSTICS ========================"
+    echo "--- TeamCity server docker logs (tail) ---"
+    docker logs --tail 80 "${TC_SERVER}" 2>&1 || true
+    echo "--- teamcity-server.log (tail) ---"
+    refresh_log
+    tail -n 150 "${SERVER_LOG}" 2>/dev/null || true
+    if [[ ${OWN_ARTIFACTORY} -eq 1 ]]; then
+      echo "--- Artifactory docker logs (tail) ---"
+      docker logs --tail 60 "${ART_CONTAINER}" 2>&1 || true
+    fi
+    echo "====================================================================="
+  fi
+  docker rm -f "${TC_AGENT}" "${TC_SERVER}" >/dev/null 2>&1 || true
+  if [[ ${OWN_ARTIFACTORY} -eq 1 ]]; then
+    docker rm -f "${ART_CONTAINER}" "${PG_CONTAINER}" >/dev/null 2>&1 || true
+  fi
+  docker network rm "${NET}" >/dev/null 2>&1 || true
+  # datadir files may be owned by the container user (uid 1000); fall back to
+  # sudo if the runner user cannot remove them.
+  rm -rf "${WORK_DIR}" 2>/dev/null || sudo rm -rf "${WORK_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Helpers ----------------------------------------------------------------
+# Snapshot the server log out of the container to a host file the runner owns.
+# The log dir is deliberately not bind-mounted: the container writes it as uid
+# 1000 with owner-only permissions, unreadable from the host on CI runners.
+refresh_log() {
+  docker cp "${TC_SERVER}:/opt/teamcity/logs/teamcity-server.log" "${SERVER_LOG}" >/dev/null 2>&1 || true
+}
+
+mnt_get()   { curl -fsS -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" -L "${BASE_URL}/mnt" 2>/dev/null || true; }
+mnt_stage() { mnt_get | grep -oiE "Stage: [A-Z_]+" | head -n1 | awk '{print $2}'; }
+
+mnt_do() {
+  local cmd="$1"; shift
+  local resp
+  resp="$(curl -fsS -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" -X POST "${BASE_URL}/mnt/do/${cmd}" "$@" 2>/dev/null || true)"
+  if [[ "${resp}" != "OK" ]]; then
+    echo "ERROR: maintenance command '${cmd}' did not return OK (got: '${resp}')" >&2
+    return 1
+  fi
+}
+
+wait_for_stage() {
+  local want="$1" deadline=$(( $(date +%s) + STARTUP_TIMEOUT )) stage=""
+  while [[ $(date +%s) -lt ${deadline} ]]; do
+    stage="$(mnt_stage || true)"
+    if [[ -n "${stage}" ]] && echo "${stage}" | grep -qiE "${want}"; then
+      echo "  -> reached stage: ${stage}"; return 0
+    fi
+    sleep 5
+  done
+  echo "ERROR: timed out waiting for stage matching '${want}' (last stage: '${stage}')" >&2
+  return 1
+}
+
+wait_for_log() {
+  local pattern="$1" deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+  while [[ $(date +%s) -lt ${deadline} ]]; do
+    refresh_log
+    if [[ -f "${SERVER_LOG}" ]] && grep -qE "${pattern}" "${SERVER_LOG}"; then return 0; fi
+    sleep 5
+  done
+  echo "ERROR: timed out waiting for log pattern: ${pattern}" >&2
+  return 1
+}
+
+# authenticated curl against TeamCity REST as the admin we create
+tc_admin() { curl -fsS -u "${TC_ADMIN_USER}:${TC_ADMIN_PASSWORD}" -H "Accept: application/json" -H "Content-Type: application/json" "$@"; }
+# authenticated curl against Artifactory REST
+art_curl() { curl -fsS -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "$@"; }
+
+# --- Docker network ---------------------------------------------------------
+docker network create "${NET}" >/dev/null 2>&1 || true
+
+# --- Stage 1: Artifactory ---------------------------------------------------
+if [[ ${OWN_ARTIFACTORY} -eq 1 ]]; then
+  echo ""
+  echo ">>> Bringing up PostgreSQL for Artifactory..."
+  docker run -d --name "${PG_CONTAINER}" --network "${NET}" \
+    -e POSTGRES_DB=artifactory \
+    -e POSTGRES_USER=artifactory \
+    -e POSTGRES_PASSWORD=password \
+    "${POSTGRES_IMAGE}" >/dev/null
+
+  echo ">>> Bringing up Artifactory (${ARTIFACTORY_IMAGE})..."
+  ART_MASTER_KEY="$(openssl rand -hex 32)"
+  docker run -d --name "${ART_CONTAINER}" --network "${NET}" \
+    -e JF_SHARED_SECURITY_MASTERKEY="${ART_MASTER_KEY}" \
+    -e JF_SHARED_DATABASE_TYPE=postgresql \
+    -e JF_SHARED_DATABASE_DRIVER=org.postgresql.Driver \
+    -e JF_SHARED_DATABASE_URL="jdbc:postgresql://${PG_CONTAINER}:5432/artifactory" \
+    -e JF_SHARED_DATABASE_USERNAME=artifactory \
+    -e JF_SHARED_DATABASE_PASSWORD=password \
+    -p 8082:8082 -p 8081:8081 \
+    "${ARTIFACTORY_IMAGE}" >/dev/null
+
+  # Host-side URL (verification / repo creation) and in-network URL (used by
+  # TeamCity server + agent containers).
+  ARTIFACTORY_URL="http://localhost:8082/artifactory"
+  ARTIFACTORY_NET_URL="http://${ART_CONTAINER}:8082/artifactory"
+
+  echo ">>> Waiting for Artifactory to become ready (this can take a few minutes)..."
+  deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+  until [[ "$(curl -s -o /dev/null -w '%{http_code}' "${ARTIFACTORY_URL}/api/system/ping" 2>/dev/null)" == "200" ]]; do
+    [[ $(date +%s) -lt ${deadline} ]] || { echo "ERROR: Artifactory did not become ready" >&2; docker logs --tail 60 "${ART_CONTAINER}" || true; exit 1; }
+    sleep 6
+  done
+  echo "  -> Artifactory is up."
+else
+  ARTIFACTORY_URL="${ARTIFACTORY_URL%/}"
+  ARTIFACTORY_NET_URL="${ARTIFACTORY_URL}"
+  echo ">>> Using existing Artifactory: ${ARTIFACTORY_URL}"
+fi
+
+# A bare /api/system/ping can return 200 before the repository/access services
+# are ready to authenticate and serve, so poll the authenticated repositories
+# endpoint (as the admin/bootstrap user) before configuring anything.
+echo ">>> Waiting for the Artifactory REST API to accept authenticated requests..."
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+api_code=""
+while [[ $(date +%s) -lt ${deadline} ]]; do
+  api_code="$(curl -s -o /dev/null -w '%{http_code}' -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" "${ARTIFACTORY_URL}/api/repositories" 2>/dev/null || echo 000)"
+  [[ "${api_code}" == "200" ]] && break
+  if [[ "${api_code}" == "401" || "${api_code}" == "403" ]]; then
+    echo "ERROR: Artifactory rejected admin credentials for user '${ART_ADMIN_USER}' (HTTP ${api_code})." >&2
+    exit 1
+  fi
+  sleep 5
+done
+[[ "${api_code}" == "200" ]] || { echo "ERROR: Artifactory REST API not ready (last HTTP ${api_code})." >&2; exit 1; }
+echo "  -> REST API ready."
+
+# Apply the Pro license (RTLIC) to a spun-up container so Pro REST features
+# (e.g. repository creation) are available. No-op for BYO Artifactory.
+if [[ ${OWN_ARTIFACTORY} -eq 1 && -n "${ARTIFACTORY_LICENSE}" ]]; then
+  echo ">>> Applying Artifactory Pro license..."
+  lic_payload="${WORK_DIR}/license.json"
+  # Safely JSON-encode the license key (may contain newlines/special chars).
+  if command -v python3 >/dev/null 2>&1; then
+    ARTIFACTORY_LICENSE="${ARTIFACTORY_LICENSE}" python3 - "${lic_payload}" <<'PY'
+import json, os, sys
+with open(sys.argv[1], "w") as f:
+    f.write(json.dumps({"licenseKey": os.environ["ARTIFACTORY_LICENSE"]}))
+PY
+  else
+    printf '{"licenseKey":"%s"}' "$(printf '%s' "${ARTIFACTORY_LICENSE}" | tr -d '\r' | sed ':a;N;$!ba;s/\n/\\n/g')" > "${lic_payload}"
+  fi
+  lic_resp="${WORK_DIR}/license-resp.txt"
+  lic_code="$(curl -s -o "${lic_resp}" -w '%{http_code}' -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" \
+    -X POST "${ARTIFACTORY_URL}/api/system/licenses" \
+    -H "Content-Type: application/json" -d @"${lic_payload}" 2>/dev/null || echo 000)"
+  if [[ "${lic_code}" == "200" ]] || grep -qi "successfully\|already" "${lic_resp}" 2>/dev/null; then
+    echo "  -> license applied (HTTP ${lic_code}): $(head -c 160 "${lic_resp}" 2>/dev/null)"
+  else
+    echo "  -> WARNING: license not applied (HTTP ${lic_code}): $(head -c 200 "${lic_resp}" 2>/dev/null)" >&2
+    echo "     Continuing; will fall back to an existing generic repo if creation is blocked." >&2
+  fi
+fi
+
+# Ensure a generic local repository to publish into.
+#   * On Artifactory Pro, PUT /api/repositories/{key} creates a dedicated repo.
+#   * On Artifactory OSS, that REST API is disabled ("available only in
+#     Artifactory Pro"), so we fall back to an existing generic local repo
+#     (OSS ships with 'example-repo-local').
+echo ">>> Ensuring a generic local repository is available (target: '${ARTIFACTORY_REPO}')..."
+repo_body="${WORK_DIR}/repo-resp.txt"
+create_code="$(curl -s -o "${repo_body}" -w '%{http_code}' -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" \
+  -X PUT "${ARTIFACTORY_URL}/api/repositories/${ARTIFACTORY_REPO}" \
+  -H "Content-Type: application/json" \
+  -d '{"rclass":"local","packageType":"generic"}' 2>/dev/null || echo 000)"
+
+if [[ "${create_code}" == "200" || "${create_code}" == "201" ]]; then
+  echo "  -> created repository '${ARTIFACTORY_REPO}' (HTTP ${create_code})."
+elif grep -qi "already exists" "${repo_body}" 2>/dev/null; then
+  echo "  -> repository '${ARTIFACTORY_REPO}' already exists."
+else
+  echo "  -> could not create repo (HTTP ${create_code}: $(head -c 160 "${repo_body}" 2>/dev/null))."
+  echo "  -> looking for an existing generic local repository to reuse..."
+  repos_json="${WORK_DIR}/repos.json"
+  curl -s -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" \
+    "${ARTIFACTORY_URL}/api/repositories?type=local&packageType=generic" -o "${repos_json}" 2>/dev/null || true
+  existing="$(grep -oE '"key"[[:space:]]*:[[:space:]]*"[^"]+"' "${repos_json}" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+  if [[ -n "${existing}" ]]; then
+    ARTIFACTORY_REPO="${existing}"
+    echo "  -> reusing existing generic local repository '${ARTIFACTORY_REPO}'."
+  else
+    echo "ERROR: could not create a repository and no existing generic local repo was found." >&2
+    echo "       Repo creation via REST needs Artifactory Pro (check the RTLIC license)." >&2
+    echo "       Alternatively set ARTIFACTORY_REPO to an existing generic repo." >&2
+    exit 1
+  fi
+fi
+
+# Ensure the runtime user (USER_NAME/PASSWORD) exists as an admin, so the plugin
+# can authenticate with those credentials. Only needed for a spun-up container
+# where the runtime creds differ from the admin/bootstrap creds.
+if [[ ${OWN_ARTIFACTORY} -eq 1 && ( "${ARTIFACTORY_USER}" != "${ART_ADMIN_USER}" || "${ARTIFACTORY_PASSWORD}" != "${ART_ADMIN_PW}" ) ]]; then
+  echo ">>> Ensuring runtime user '${ARTIFACTORY_USER}' exists (admin)..."
+  user_payload="{\"name\":\"${ARTIFACTORY_USER}\",\"email\":\"${ARTIFACTORY_USER}@e2e.local\",\"password\":\"${ARTIFACTORY_PASSWORD}\",\"admin\":true}"
+  # PUT creates (or replaces); POST updates an existing user's password. Do both
+  # so it works whether or not the user already exists (e.g. 'admin').
+  curl -s -o /dev/null -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" \
+    -X PUT "${ARTIFACTORY_URL}/api/security/users/${ARTIFACTORY_USER}" \
+    -H "Content-Type: application/json" -d "${user_payload}" 2>/dev/null || true
+  curl -s -o /dev/null -u "${ART_ADMIN_USER}:${ART_ADMIN_PW}" \
+    -X POST "${ARTIFACTORY_URL}/api/security/users/${ARTIFACTORY_USER}" \
+    -H "Content-Type: application/json" -d "${user_payload}" 2>/dev/null || true
+  # Verify the runtime credentials now authenticate (use an authenticated
+  # endpoint; /api/system/ping does not require auth).
+  deadline=$(( $(date +%s) + 120 ))
+  until [[ "$(curl -s -o /dev/null -w '%{http_code}' -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_URL}/api/repositories" 2>/dev/null || echo 000)" == "200" ]]; do
+    [[ $(date +%s) -lt ${deadline} ]] || { echo "ERROR: runtime user '${ARTIFACTORY_USER}' cannot authenticate." >&2; exit 1; }
+    sleep 3
+  done
+  echo "  -> runtime user ready."
+fi
+
+# --- Stage 2: pre-seed plugin config + start TeamCity server ----------------
+echo ""
+echo ">>> Pre-seeding the Artifactory server connection (config/artifactory-config.xml)..."
+cat > "${DATA_DIR}/config/artifactory-config.xml" <<EOF
+<serializableServers>
+  <serializableServers>
+    <serializableServer>
+      <id>0</id>
+      <url>${ARTIFACTORY_NET_URL}</url>
+      <defaultDeployerCredentials>
+        <username>${ARTIFACTORY_USER}</username>
+        <password>${ARTIFACTORY_PASSWORD}</password>
+      </defaultDeployerCredentials>
+      <useDifferentResolverCredentials>false</useDifferentResolverCredentials>
+      <defaultResolverCredentials><username></username><password></password></defaultResolverCredentials>
+      <timeout>300</timeout>
+    </serializableServer>
+  </serializableServers>
+</serializableServers>
+EOF
+
+echo ">>> Starting TeamCity server container..."
+docker run -d --name "${TC_SERVER}" --network "${NET}" \
+  -e TEAMCITY_SERVER_MEM_OPTS="-Xmx1g -XX:MaxMetaspaceSize=400m" \
+  -v "${DATA_DIR}:/data/teamcity_server/datadir" \
+  -p "${TC_PORT}:8111" \
+  "${TEAMCITY_IMAGE}" >/dev/null
+
+echo ">>> Waiting for the server web endpoint to respond..."
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+until curl -fsS -o /dev/null "${BASE_URL}/mnt" 2>/dev/null; do
+  [[ $(date +%s) -lt ${deadline} ]] || { echo "ERROR: server did not become reachable" >&2; exit 1; }
+  sleep 5
+done
+curl -fsS -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" -o /dev/null "${BASE_URL}/" 2>/dev/null || true
+curl -fsS -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" -o /dev/null "${BASE_URL}/mnt" 2>/dev/null || true
+
+# --- Stage 3: first-run wizard ---------------------------------------------
+echo ""
+echo ">>> Confirming first start..."
+wait_for_stage "FIRST_START_SCREEN"
+mnt_do "goNewInstallation" -d "restore=false"
+
+echo ">>> Selecting internal (HSQLDB) database..."
+wait_for_stage "DB_SETTINGS_SCREEN"
+mnt_do "goNewDatabase" -d "dbType=HSQLDB2"
+
+echo ">>> Accepting license agreement..."
+wait_for_stage "LICENSE_AGREEMENT_SCREEN"
+mnt_do "acceptLicenseAgreement"
+
+echo ">>> Waiting for plugin initialization to complete..."
+wait_for_log "Plugins initialization completed"
+
+# --- Stage 4: create admin via the superuser token --------------------------
+echo ""
+echo ">>> Waiting for the superuser authentication token in the log..."
+SU_TOKEN=""
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+while [[ $(date +%s) -lt ${deadline} ]]; do
+  refresh_log
+  SU_TOKEN="$(grep -aE "Super user authentication token" "${SERVER_LOG}" 2>/dev/null | grep -oE '[0-9]{6,}' | tail -1 || true)"
+  [[ -n "${SU_TOKEN}" ]] && break
+  sleep 5
+done
+[[ -n "${SU_TOKEN}" ]] || { echo "ERROR: could not find superuser token in server log" >&2; exit 1; }
+
+echo ">>> Creating admin user '${TC_ADMIN_USER}'..."
+create_admin() {
+  curl -fsS -u ":${SU_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/json" \
+    -X POST "${BASE_URL}/app/rest/users" \
+    -d "{\"username\":\"${TC_ADMIN_USER}\",\"password\":\"${TC_ADMIN_PASSWORD}\",\"roles\":{\"role\":[{\"roleId\":\"SYSTEM_ADMIN\",\"scope\":\"g\"}]}}" >/dev/null
+}
+# REST may not be immediately ready right after init; retry briefly.
+for i in $(seq 1 20); do
+  if create_admin 2>/dev/null; then echo "  -> admin created."; break; fi
+  [[ $i -eq 20 ]] && { echo "ERROR: failed to create admin user via REST" >&2; exit 1; }
+  sleep 5
+done
+
+# --- Stage 5: agent bring-up + authorization --------------------------------
+echo ""
+echo ">>> Starting TeamCity agent container..."
+docker run -d --name "${TC_AGENT}" --network "${NET}" \
+  -e SERVER_URL="http://${TC_SERVER}:8111" \
+  -e TEAMCITY_AGENT_MEM_OPTS="-Xmx512m" \
+  "${TEAMCITY_AGENT_IMAGE}" >/dev/null
+
+echo ">>> Waiting for the agent to register..."
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+until tc_admin "${BASE_URL}/app/rest/agents?locator=authorized:any" 2>/dev/null | grep -qiE "\"count\":[1-9]"; do
+  [[ $(date +%s) -lt ${deadline} ]] || { echo "ERROR: agent did not register" >&2; exit 1; }
+  sleep 5
+done
+
+echo ">>> Authorizing the agent..."
+tc_admin -X PUT "${BASE_URL}/app/rest/agents/id:1/authorizedInfo" \
+  -d '{"status":true,"comment":{"text":"e2e auto"}}' >/dev/null
+
+echo ">>> Waiting for the agent to be connected + authorized..."
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+until tc_admin "${BASE_URL}/app/rest/agents?locator=authorized:true,connected:true" 2>/dev/null | grep -qiE "\"count\":[1-9]"; do
+  [[ $(date +%s) -lt ${deadline} ]] || { echo "ERROR: agent never became connected+authorized" >&2; exit 1; }
+  sleep 5
+done
+echo "  -> agent ready."
+
+# --- Stage 6: project + build config + step ---------------------------------
+echo ""
+echo ">>> Creating project + build configuration..."
+tc_admin -X POST "${BASE_URL}/app/rest/projects" -d '{"name":"e2e","id":"e2e"}' >/dev/null
+tc_admin -X POST "${BASE_URL}/app/rest/buildTypes" -d '{"name":"publish","project":{"id":"e2e"}}' >/dev/null
+
+STEP_JSON="${WORK_DIR}/step.json"
+cat > "${STEP_JSON}" <<EOF
+{
+  "name": "publish-step",
+  "type": "simpleRunner",
+  "properties": {
+    "property": [
+      { "name": "use.custom.script", "value": "true" },
+      { "name": "script.content", "value": "echo hello-e2e > artifact.txt\ncat artifact.txt" },
+      { "name": "teamcity.step.mode", "value": "default" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.urlId", "value": "0" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.url", "value": "${ARTIFACTORY_NET_URL}" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.timeout", "value": "300" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.useSpecs", "value": "true" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.uploadSpec", "value": "{\"files\":[{\"pattern\":\"artifact.txt\",\"target\":\"${ARTIFACTORY_REPO}/e2e/\"}]}" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.deployArtifacts", "value": "true" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.publishBuildInfo", "value": "true" },
+      { "name": "org.jfrog.artifactory.selectedDeployableServer.overrideDefaultDeployerCredentials", "value": "false" }
+    ]
+  }
+}
+EOF
+
+echo ">>> Adding the Artifactory publish step..."
+tc_admin -X POST "${BASE_URL}/app/rest/buildTypes/id:${BUILD_NAME}/steps" --data-binary @"${STEP_JSON}" >/dev/null
+
+# --- Stage 7: run the build -------------------------------------------------
+echo ""
+echo ">>> Triggering the build..."
+RESP="$(tc_admin -X POST "${BASE_URL}/app/rest/buildQueue" -d "{\"buildType\":{\"id\":\"${BUILD_NAME}\"}}")"
+BID="$(printf '%s' "${RESP}" | grep -oE '"id":[0-9]+' | head -1 | grep -oE '[0-9]+' || true)"
+[[ -n "${BID}" ]] || { echo "ERROR: could not determine queued build id. Response: ${RESP}" >&2; exit 1; }
+echo "  -> queued build id: ${BID}"
+
+echo ">>> Waiting for the build to finish..."
+STATE="" STATUS=""
+deadline=$(( $(date +%s) + STARTUP_TIMEOUT ))
+# NOTE: keep these extractions tolerant of empty responses (a queued build's
+# id may 404 on /builds until it starts running) and of grep exit codes; under
+# 'set -euo pipefail' an unguarded failing pipeline would abort the whole loop.
+while [[ $(date +%s) -lt ${deadline} ]]; do
+  INFO="$(tc_admin "${BASE_URL}/app/rest/builds/id:${BID}" 2>/dev/null || true)"
+  STATE="$(printf '%s' "${INFO}" | grep -oE -m1 '"state":"[a-z]+"' | cut -d'"' -f4 || true)"
+  STATUS="$(printf '%s' "${INFO}" | grep -oE -m1 '"status":"[A-Z]+"' | cut -d'"' -f4 || true)"
+  echo "  [build ${BID}] state=${STATE:-queued?} status=${STATUS:-?}"
+  [[ "${STATE}" == "finished" ]] && break
+  sleep 6
+done
+
+# --- Stage 8: assertions ----------------------------------------------------
+echo ""
+echo ">>> Verifying results..."
+FAILED=0
+
+if [[ "${STATE}" != "finished" ]]; then
+  echo "FAIL: build did not finish within the timeout." >&2
+  FAILED=1
+elif [[ "${STATUS}" != "SUCCESS" ]]; then
+  echo "FAIL: build finished with status '${STATUS}' (expected SUCCESS)." >&2
+  BUILD_LOG="${WORK_DIR}/build.log"
+  tc_admin "${BASE_URL}/downloadBuildLog.html?buildId=${BID}" >"${BUILD_LOG}" 2>/dev/null || true
+  echo "----- artifactory/jfrog lines from build log -----" >&2
+  grep -inE "artifactory|jfrog|spec|deploy|upload|unauthorized|forbidden|not found|40[0-9]|could not|exception" "${BUILD_LOG}" 2>/dev/null | tail -n 50 >&2 || true
+  echo "----- build log (tail) -----" >&2
+  tail -n 50 "${BUILD_LOG}" 2>/dev/null >&2 || true
+  FAILED=1
+else
+  echo "PASS: build finished with status SUCCESS."
+fi
+
+# Artifact must exist in Artifactory.
+ART_CODE="$(art_curl -o /dev/null -w '%{http_code}' "${ARTIFACTORY_URL}/api/storage/${ARTIFACTORY_REPO}/e2e/artifact.txt" 2>/dev/null || echo 000)"
+if [[ "${ART_CODE}" == "200" ]]; then
+  echo "PASS: artifact published -> ${ARTIFACTORY_REPO}/e2e/artifact.txt"
+else
+  echo "FAIL: artifact not found in Artifactory (HTTP ${ART_CODE})." >&2
+  FAILED=1
+fi
+
+# Build-info must exist in Artifactory.
+BI_CODE="$(art_curl -o /dev/null -w '%{http_code}' "${ARTIFACTORY_URL}/api/build/${BUILD_NAME}" 2>/dev/null || echo 000)"
+if [[ "${BI_CODE}" == "200" ]]; then
+  echo "PASS: build-info published -> ${BUILD_NAME}"
+else
+  echo "FAIL: build-info not found in Artifactory (HTTP ${BI_CODE})." >&2
+  FAILED=1
+fi
+
+echo ""
+echo ">>> TeamCity server JVM:"
+refresh_log
+grep -oE "Java: [0-9][^;]*" "${SERVER_LOG}" | head -n1 || true
+
+echo ""
+if [[ ${FAILED} -ne 0 ]]; then
+  echo "E2E build-and-publish test: FAILED"
+  exit 1
+fi
+echo "E2E build-and-publish test: PASSED"

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.version>${project.version}</plugin.version>
-        <teamcity.version>2025.07</teamcity.version>
+        <teamcity.version>2025.11</teamcity.version>
         <build.info.version>2.38.1</build.info.version>
         <build.info.gradle.version>4.30.1</build.info.gradle.version>
     </properties>
@@ -118,6 +118,15 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <version>2.17.2</version>
+            </dependency>
+            <!-- build-info-api pulls in jackson-annotations 2.14.1, which is missing enum
+                 constants that jackson-databind 2.17.2 references (JsonFormat.Feature.
+                 READ_UNKNOWN_ENUM_VALUES_*, added in 2.15). Pin it to match databind so the
+                 Docker runner can deserialize daemon responses without NoSuchFieldError. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
                 <version>2.17.2</version>
             </dependency>
             <dependency>
@@ -262,6 +271,10 @@
                         <groupId>commons-httpclient</groupId>
                         <artifactId>commons-httpclient</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>net.i2p.crypto</groupId>
+                        <artifactId>eddsa</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -333,6 +346,10 @@
                     <exclusion>
                         <groupId>commons-httpclient</groupId>
                         <artifactId>commons-httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.i2p.crypto</groupId>
+                        <artifactId>eddsa</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -608,7 +625,8 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <version>4.1.125.Final-linux-x86_64</version>
+                <version>4.1.125.Final</version>
+                <classifier>linux-x86_64</classifier>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -618,7 +636,8 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>4.1.125.Final-osx-x86_64</version>
+                <version>4.1.125.Final</version>
+                <classifier>osx-x86_64</classifier>
             </dependency>
             <!-- Override vulnerable OWASP HTML sanitizer -->
             <dependency>
@@ -824,8 +843,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <release>21</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.version>${project.version}</plugin.version>
         <teamcity.version>2025.11</teamcity.version>
-        <build.info.version>2.38.1</build.info.version>
-        <build.info.gradle.version>4.30.1</build.info.gradle.version>
+        <build.info.version>2.43.9</build.info.version>
+        <build.info.gradle.version>6.0.4</build.info.gradle.version>
     </properties>
 
     <developers>

--- a/server/src/main/java/org/jfrog/teamcity/server/project/BaseReleaseManagementTab.java
+++ b/server/src/main/java/org/jfrog/teamcity/server/project/BaseReleaseManagementTab.java
@@ -140,7 +140,7 @@ public abstract class BaseReleaseManagementTab extends BuildTypeTab {
             ArrayList<BranchEx> branchExes = Lists.newArrayList();
             BranchEx branch;
             //If the user is on the __all_branches__ view, take the default branch
-            if (branchBean.isWildcardBranch()) {
+            if (branchBean.isAllBranches()) {
                 branch = ((BuildTypeEx) buildType).getBranch("<default>");
             } else {
                 String userBranch = branchBean.getUserBranch();

--- a/server/src/main/java/org/jfrog/teamcity/server/runner/BaseRunTypeConfigPropertiesProcessor.java
+++ b/server/src/main/java/org/jfrog/teamcity/server/runner/BaseRunTypeConfigPropertiesProcessor.java
@@ -17,11 +17,11 @@
 package org.jfrog.teamcity.server.runner;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.extractor.clientConfiguration.util.PublishedItemsHelper;
 import org.jfrog.teamcity.common.RunnerParameterKeys;
 import org.jfrog.teamcity.server.global.DeployableArtifactoryServers;


### PR DESCRIPTION
## Summary
- Bumps `teamcity.version` to 2025.11 and the compiler release to Java 21 (was 17)
- Pins `jackson-annotations` to match `jackson-databind` (2.17.2) to avoid a `NoSuchFieldError` in the Docker runner
- Fixes the `netty-transport-native-epoll`/`netty-transport-native-kqueue` coordinates to use a proper `classifier` instead of baking the OS/arch into the version string
- Excludes the unused `eddsa` transitive dependency
- CI now builds/tests on JDK 21 (`actions/checkout`/`actions/setup-java` bumped to v4)

## Test plan
- [x] `mvn test` passes under JDK 21 (50 tests, 0 failures/errors)
- [x] Built plugin verified end-to-end against a live TeamCity 2025.11 server + agent (server plugin reload, agent plugin resync, real build runs)
- [x] Confirmed no regression vs. plain `origin/master` (which has a pre-existing, unrelated Maven Central TLS/network issue for two artifacts introduced in #172, reproduced independently of this change)
