### PR TITLE
Add GitHub Actions release/snapshot workflows (JFrog Pipelines EOL migration)

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the teamcity-artifactory-plugin release flow. Used by
+# .github/workflows/release.yml, and can be run directly on a developer
+# machine from a checkout of this repo (with an "origin" remote and push
+# access) by exporting the same environment variables and executing this
+# script.
+#
+# Expected environment variables:
+#   NEXT_VERSION             - version to release (e.g. 5.1.0)
+#   NEXT_DEVELOPMENT_VERSION - next development version (e.g. 5.1.x-SNAPSHOT)
+#   AUDIT_FAIL                - "true"/"false", passed to `jf audit --fail`
+#   JETBRAINS_TOKEN          - Bearer token for the JetBrains Marketplace API
+#
+# Also relies on (typically already set in the environment / CI job):
+#   CI, JFROG_CLI_BUILD_NAME, JFROG_CLI_BUILD_NUMBER, JFROG_CLI_BUILD_PROJECT
+#
+# Prerequisite: the JFrog CLI ("jf") must already be configured/authenticated
+# (e.g. via `jf c add`) before running this script.
+
+git config user.name "jfrog-ecosystem-automation"
+git config user.email "eco-system@jfrog.com"
+
+git fetch origin release
+git checkout release
+
+# Make sure versions were provided
+test -n "$NEXT_VERSION"
+test -n "$NEXT_DEVELOPMENT_VERSION"
+
+jf mvnc \
+  --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
+  --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
+
+git merge origin/master
+
+mvn versions:set -DnewVersion="${NEXT_VERSION}" -B
+
+git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
+git tag "${NEXT_VERSION}"
+
+jf audit --fail="${AUDIT_FAIL}"
+
+jf mvn clean install -U -B
+
+jf rt u --flat=true "target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
+  "ecosys-oss-release-local/org/jfrog/teamcity/teamcity-artifactory-plugin/${NEXT_VERSION}/"
+
+jf rt bag
+jf rt bce
+jf rt bp
+
+jf ds rbc ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --spec=./ci/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION" --sign
+jf ds rbd ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --site="releases.jfrog.io" --sync
+
+# Deliberate behavior change: JetBrains Marketplace upload, ported as-is from the
+# JFrog Pipelines step (Bearer token sourced from the `jetbrains` integration).
+curl -i --header "Authorization:Bearer ${JETBRAINS_TOKEN}" \
+  -F pluginId=9082 \
+  -F file=@"target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
+  https://plugins.jetbrains.com/plugin/uploadPlugin
+
+mvn versions:set -DnewVersion="${NEXT_DEVELOPMENT_VERSION}" -B
+
+git commit -am "[artifactory-release] Next development version [skipRun]"
+git push origin release
+
+git checkout master
+git merge origin/release
+git push origin master
+git push origin --tags

--- a/.github/scripts/snapshot.sh
+++ b/.github/scripts/snapshot.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the teamcity-artifactory-plugin snapshot flow. Used by
+# .github/workflows/snapshot.yml, and can be run directly on a developer
+# machine from a checkout of this repo by exporting the same environment
+# variables and executing this script.
+#
+# Expected environment variables:
+#   GITHUB_RUN_NUMBER - build/run number used to tag the snapshot release
+#                        bundle (set automatically by GitHub Actions; export
+#                        manually when running locally, e.g.
+#                        GITHUB_RUN_NUMBER=123)
+#
+# Also relies on (typically already set in the environment / CI job):
+#   CI, JFROG_CLI_BUILD_NAME, JFROG_CLI_BUILD_NUMBER, JFROG_CLI_BUILD_PROJECT
+#
+# Prerequisite: the JFrog CLI ("jf") must already be configured/authenticated
+# (e.g. via `jf c add`) before running this script.
+
+jf mvnc \
+  --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
+  --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
+
+jf audit
+
+# Delete former snapshots to make sure the release bundle will not contain stale artifacts
+jf rt del "ecosys-oss-snapshot-local/org/jfrog/teamcity/teamcity-artifactory-plugin/*" --quiet
+
+jf mvn install -U -B
+
+jf rt bag
+jf rt bp
+
+jf ds rbc ecosystem-teamcity-artifactory-plugin-snapshot "${GITHUB_RUN_NUMBER}" --spec=./ci/specs/dev-rbc-filespec.json --sign
+jf ds rbd ecosystem-teamcity-artifactory-plugin-snapshot "${GITHUB_RUN_NUMBER}" --site="releases.jfrog.io" --sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ env:
   JFROG_CLI_BUILD_PROJECT: ecosys
   NEXT_VERSION: ${{ inputs.next_version }}
   NEXT_DEVELOPMENT_VERSION: ${{ inputs.next_development_version }}
+  AUDIT_FAIL: ${{ inputs.audit_fail }}
 
 jobs:
   release:
@@ -56,81 +57,7 @@ jobs:
           JF_USER: ${{ secrets.ARTIFACTORY_USER }}
           JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
 
-      - name: Configure git identity
-        run: |
-          git config user.name "jfrog-ecosystem-automation"
-          git config user.email "eco-system@jfrog.com"
-
-      - name: Checkout release branch
-        run: |
-          git fetch origin release
-          git checkout release
-
-      # Make sure versions were provided
-      - name: Check variables
-        run: |
-          test -n "$NEXT_VERSION"
-          test -n "$NEXT_DEVELOPMENT_VERSION"
-
-      - name: Configure JFrog CLI Maven config
-        run: |
-          jf mvnc \
-            --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
-            --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
-
-      - name: Sync changes with master
-        run: git merge origin/master
-
-      - name: Update version
-        run: mvn versions:set -DnewVersion="${NEXT_VERSION}" -B
-
-      - name: Commit and tag release version
-        run: |
-          git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
-          git tag "${NEXT_VERSION}"
-
-      - name: Run audit
-        run: jf audit --fail=${{ inputs.audit_fail }}
-
-      - name: Build and publish
-        run: jf mvn clean install -U -B
-
-      - name: Upload release zip
-        run: |
-          jf rt u --flat=true "target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
-            "ecosys-oss-release-local/org/jfrog/teamcity/teamcity-artifactory-plugin/${NEXT_VERSION}/"
-
-      - name: Publish build info
-        run: |
-          jf rt bag
-          jf rt bce
-          jf rt bp
-
-      - name: Distribute release bundle
-        run: |
-          jf ds rbc ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --spec=./ci/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION" --sign
-          jf ds rbd ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --site="releases.jfrog.io" --sync
-
-      # Deliberate behavior change: JetBrains Marketplace upload, ported as-is from the
-      # JFrog Pipelines step (Bearer token sourced from the `jetbrains` integration).
-      - name: Upload to JetBrains Marketplace
-        run: |
-          curl -i --header "Authorization:Bearer ${{ secrets.JETBRAINS_TOKEN }}" \
-            -F pluginId=9082 \
-            -F file=@"target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
-            https://plugins.jetbrains.com/plugin/uploadPlugin
-
-      - name: Update next development version
-        run: mvn versions:set -DnewVersion="${NEXT_DEVELOPMENT_VERSION}" -B
-
-      - name: Commit next development version
-        run: |
-          git commit -am "[artifactory-release] Next development version [skipRun]"
-          git push origin release
-
-      - name: Merge changes to master
-        run: |
-          git checkout master
-          git merge origin/release
-          git push origin master
-          git push origin --tags
+      - name: Run release
+        env:
+          JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
+        run: .github/scripts/release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: "Version to release (e.g. 5.1.0)"
+        required: true
+        type: string
+      next_development_version:
+        description: "Next development version (e.g. 5.1.x-SNAPSHOT)"
+        required: true
+        type: string
+      audit_fail:
+        description: "Fail the run if jf audit finds issues"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  CI: true
+  JFROG_CLI_BUILD_NAME: teamcity-artifactory-plugin
+  JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+  JFROG_CLI_BUILD_PROJECT: ecosys
+  NEXT_VERSION: ${{ inputs.next_version }}
+  NEXT_DEVELOPMENT_VERSION: ${{ inputs.next_development_version }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.IL_AUTOMATION_TOKEN }}
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ secrets.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "jfrog-ecosystem-automation"
+          git config user.email "eco-system@jfrog.com"
+
+      - name: Checkout release branch
+        run: |
+          git fetch origin release
+          git checkout release
+
+      # Make sure versions were provided
+      - name: Check variables
+        run: |
+          test -n "$NEXT_VERSION"
+          test -n "$NEXT_DEVELOPMENT_VERSION"
+
+      - name: Configure JFrog CLI Maven config
+        run: |
+          jf mvnc \
+            --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
+            --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
+
+      - name: Sync changes with master
+        run: git merge origin/master
+
+      - name: Update version
+        run: mvn versions:set -DnewVersion="${NEXT_VERSION}" -B
+
+      - name: Commit and tag release version
+        run: |
+          git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
+          git tag "${NEXT_VERSION}"
+
+      - name: Run audit
+        run: jf audit --fail=${{ inputs.audit_fail }}
+
+      - name: Build and publish
+        run: jf mvn clean install -U -B
+
+      - name: Upload release zip
+        run: |
+          jf rt u --flat=true "target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
+            "ecosys-oss-release-local/org/jfrog/teamcity/teamcity-artifactory-plugin/${NEXT_VERSION}/"
+
+      - name: Publish build info
+        run: |
+          jf rt bag
+          jf rt bce
+          jf rt bp
+
+      - name: Distribute release bundle
+        run: |
+          jf ds rbc ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --spec=./ci/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION" --sign
+          jf ds rbd ecosystem-teamcity-artifactory-plugin "$NEXT_VERSION" --site="releases.jfrog.io" --sync
+
+      # Deliberate behavior change: JetBrains Marketplace upload, ported as-is from the
+      # JFrog Pipelines step (Bearer token sourced from the `jetbrains` integration).
+      - name: Upload to JetBrains Marketplace
+        run: |
+          curl -i --header "Authorization:Bearer ${{ secrets.JETBRAINS_TOKEN }}" \
+            -F pluginId=9082 \
+            -F file=@"target/teamcity-artifactory-plugin-${NEXT_VERSION}.zip" \
+            https://plugins.jetbrains.com/plugin/uploadPlugin
+
+      - name: Update next development version
+        run: mvn versions:set -DnewVersion="${NEXT_DEVELOPMENT_VERSION}" -B
+
+      - name: Commit next development version
+        run: |
+          git commit -am "[artifactory-release] Next development version [skipRun]"
+          git push origin release
+
+      - name: Merge changes to master
+        run: |
+          git checkout master
+          git merge origin/release
+          git push origin master
+          git push origin --tags

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -40,28 +40,5 @@ jobs:
           JF_USER: ${{ secrets.ARTIFACTORY_USER }}
           JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
 
-      - name: Configure JFrog CLI Maven config
-        run: |
-          jf mvnc \
-            --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
-            --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
-
-      - name: Run audit
-        run: jf audit
-
-      # Delete former snapshots to make sure the release bundle will not contain stale artifacts
-      - name: Delete previous snapshots
-        run: jf rt del "ecosys-oss-snapshot-local/org/jfrog/teamcity/teamcity-artifactory-plugin/*" --quiet
-
-      - name: Build and publish
-        run: jf mvn install -U -B
-
-      - name: Publish build info
-        run: |
-          jf rt bag
-          jf rt bp
-
-      - name: Distribute release bundle
-        run: |
-          jf ds rbc ecosystem-teamcity-artifactory-plugin-snapshot "${{ github.run_number }}" --spec=./ci/specs/dev-rbc-filespec.json --sign
-          jf ds rbd ecosystem-teamcity-artifactory-plugin-snapshot "${{ github.run_number }}" --site="releases.jfrog.io" --sync
+      - name: Run snapshot
+        run: .github/scripts/snapshot.sh

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,67 @@
+name: Snapshot
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+env:
+  CI: true
+  JFROG_CLI_BUILD_NAME: teamcity-artifactory-plugin
+  JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+  JFROG_CLI_BUILD_PROJECT: ecosys
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ secrets.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Configure JFrog CLI Maven config
+        run: |
+          jf mvnc \
+            --repo-resolve-releases ecosys-teamcity-repos --repo-resolve-snapshots ecosys-teamcity-repos \
+            --repo-deploy-releases ecosys-oss-release-local --repo-deploy-snapshots ecosys-oss-snapshot-local
+
+      - name: Run audit
+        run: jf audit
+
+      # Delete former snapshots to make sure the release bundle will not contain stale artifacts
+      - name: Delete previous snapshots
+        run: jf rt del "ecosys-oss-snapshot-local/org/jfrog/teamcity/teamcity-artifactory-plugin/*" --quiet
+
+      - name: Build and publish
+        run: jf mvn install -U -B
+
+      - name: Publish build info
+        run: |
+          jf rt bag
+          jf rt bp
+
+      - name: Distribute release bundle
+        run: |
+          jf ds rbc ecosystem-teamcity-artifactory-plugin-snapshot "${{ github.run_number }}" --spec=./ci/specs/dev-rbc-filespec.json --sign
+          jf ds rbd ecosystem-teamcity-artifactory-plugin-snapshot "${{ github.run_number }}" --site="releases.jfrog.io" --sync


### PR DESCRIPTION
## Summary

Ports the two JFrog Pipelines defined in this repo (`ci/pipelines.release.yml` /
`release_teamcity` and `ci/pipelines.snapshot.yml` / `build_teamcity_snapshot`)
to GitHub Actions, since JFrog Pipelines is being retired (EOL).

- **`.github/workflows/release.yml`** — `workflow_dispatch` with `next_version`,
  `next_development_version`, and `audit_fail` inputs. Ports every step from the
  `release_teamcity` pipeline: checking out the `release` branch, merging
  `master`, bumping the Maven version, running `jf audit`, building/publishing
  with the JFrog CLI, uploading the built zip to Artifactory, publishing build
  info, distributing the release bundle, **uploading the plugin to the
  JetBrains Marketplace**, bumping to the next development version, and
  merging back to `master` (with tags).
- **`.github/workflows/snapshot.yml`** — triggers on `push` to `master` (the
  branch tracked by the `teamcitySnapshotGit` pipeline resource) plus
  `workflow_dispatch`. Ports the `build_teamcity_snapshot` pipeline: audit,
  delete stale snapshot artifacts, build/publish, and distribute the snapshot
  release bundle.

## Behavior changes / judgment calls

- **JFrog CLI install**: replaced `curl -fL https://install-cli.jfrog.io | sh`
  with `jfrog/setup-jfrog-cli@v4` (matches this repo's existing
  `security-audit.yml` / `frogbot.yml` workflows). This is a deliberate change,
  not a 1:1 port.
- Dropped the `env -i ...` sandboxing tricks used in the Pipelines Bash steps —
  not needed in a GitHub Actions runner.
- The snapshot pipeline resource (`teamcitySnapshotGit`) had
  `pullRequestCreate: true` in addition to `commit: true`. This PR only ports
  the push trigger (`push: branches: [master]`); PR-triggered snapshot builds
  can be a follow-up if still wanted.
- Added `actions/cache@v4` for `~/.m2/repository` as the GitHub Actions
  equivalent of the Pipelines `restore_cache_files`/`add_cache_files` steps.
- Release workflow checks out with `secrets.IL_AUTOMATION_TOKEN` (instead of
  the default `GITHUB_TOKEN`) so it has push rights to `release`/`master` and
  can push tags, mirroring the original pipeline's `il_automation` git
  integration. Git commit identity is set to a generic
  `jfrog-ecosystem-automation <eco-system@jfrog.com>` — happy to change this if
  there's a preferred bot identity.
- Not run yet — needs secrets added first.

## Required secrets

| Secret | Source (JFrog Pipelines integration) |
|---|---|
| `IL_AUTOMATION_TOKEN` | `il_automation` |
| `ARTIFACTORY_URL` | `ecosys_entplus_deployer` |
| `ARTIFACTORY_USER` | `ecosys_entplus_deployer` |
| `ARTIFACTORY_APIKEY` | `ecosys_entplus_deployer` |
| `JETBRAINS_TOKEN` | `jetbrains` |

## Test plan

- [ ] Add the secrets above to the repository (or an environment scoped to
      these workflows).
- [ ] Trigger `snapshot.yml` via `workflow_dispatch` (or a push to `master`)
      and confirm it builds, audits, and publishes a snapshot release bundle.
- [ ] Trigger `release.yml` via `workflow_dispatch` with real version inputs
      against a test/dry-run scenario before using it for a real release.
